### PR TITLE
Fixed compiler error on multiline strings in testSockets.ceylon

### DIFF
--- a/test-source/test/ceylon/io/testSockets.ceylon
+++ b/test-source/test/ceylon/io/testSockets.ceylon
@@ -109,10 +109,10 @@ void testGrrr(){
 //    value socket = connector.connect();
     print("Getting ``uri.humanRepresentation``");
     value request = "GET ``uri.path.string`` HTTP/1.1
-Host: ``host``
-User-Agent:Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/536.11 (KHTML, like Gecko) Chrome/20.0.1132.57 Safari/536.11
-
-";
+                     Host: ``host``
+                     User-Agent:Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/536.11 (KHTML, like Gecko) Chrome/20.0.1132.57 Safari/536.11
+                     
+                     ";
     print(request);
     
     print("Writing request");


### PR DESCRIPTION
backend message: multiline string content should align be aligned with start of string: string begins at character position 21
