### PR TITLE
test moules should ddepend on ceylon.net version 0.5.1

### DIFF
--- a/test-source/test/ceylon/io/module.ceylon
+++ b/test-source/test/ceylon/io/module.ceylon
@@ -3,6 +3,6 @@ module test.ceylon.io '0.5' {
     import ceylon.test '0.5';
     import ceylon.file '0.5';
     import ceylon.io '0.5';
-    import ceylon.net '0.5';
+    import ceylon.net '0.5.1';
     import ceylon.collection '0.5';
 }

--- a/test-source/test/ceylon/net/module.ceylon
+++ b/test-source/test/ceylon/net/module.ceylon
@@ -1,7 +1,7 @@
 module test.ceylon.net '0.5' {
     import ceylon.language '0.5';
     import ceylon.test '0.5';
-    import ceylon.net '0.5';
+    import ceylon.net '0.5.1';
     import ceylon.json '0.5';
     import ceylon.file '0.5';
     import ceylon.io '0.5';


### PR DESCRIPTION
In the IDE, few of the test modules complained that ceylon.net depends on a different version than one being built, so I bumped their dependencies up to 0.5.1
