### PR TITLE
ceylon.test: run Callables as tests

### DIFF
--- a/source/ceylon/test/TestRunner.ceylon
+++ b/source/ceylon/test/TestRunner.ceylon
@@ -13,7 +13,7 @@ import ceylon.test.internal {
 }
 
 "Alias for program elements from which tests can be run."
-shared alias TestSource => Module|Package|ClassDeclaration|FunctionDeclaration|Class|FunctionModel|String;
+shared alias TestSource => Module|Package|ClassDeclaration|FunctionDeclaration|Class|FunctionModel|String|Anything()|[Anything(), String];
 
 "Alias for functions which filter tests. 
  Should return true if the given test should be run."

--- a/source/ceylon/test/internal/TestRunnerImpl.ceylon
+++ b/source/ceylon/test/internal/TestRunnerImpl.ceylon
@@ -192,4 +192,10 @@ void initExecutorsForSource(SequenceBuilder<TestExecutor> executors, TestSource 
     else if( is String source ) {
         initExecutorsForTypeLiteral(executors, source, filter, comparator);
     }
+    else if( is Anything() source) {
+        executors.append(CallableTestExecutor(source));
+    }
+    else if( is [Anything(), String] source) {
+        executors.append(CallableTestExecutor(*source));
+    }
 }


### PR DESCRIPTION
This allows to run `Anything()`s as tests. If you pack them into a tuple, you can also name them.

With this change, you can run a test function several times with different parameters, like this:

``` ceylon
"Runs [[testFile]] for each file in [[testFileDirectory]]."
TestRunner runner = createTestRunner([
    for (file in testFileDirectory.files())
        [() => testFile(file), file.name]
        // or, if you don’t care about the name:
        // () => testFile(file)
]);
```

The code for the `CallableTestExecutor` is mostly copied from the `MethodTestExecutor`, with a lot of stuff that’s not possible on `Callable`s (callbacks from annotations etc.) removed.

What do you think?
