### PR TITLE
Fix for issue #161 - implement mutable CharacterBuffer API

### DIFF
--- a/source/ceylon/io/buffer/CharacterBuffer.ceylon
+++ b/source/ceylon/io/buffer/CharacterBuffer.ceylon
@@ -1,70 +1,32 @@
+import ceylon.io.buffer.impl { StringBackedCharacterBufferImpl, CharacterBufferImpl }
 
-"Represents a read-only [[Character]] [[Buffer]] whose underlying data
- is read from the given [[string]]. This buffer starts ready to be read,
- with the [[position]] set to `0` and the [[limit]] set to size of the
- given [[string]]."
+"Represents a buffer of characters.
+ 
+ You can create new instances with [[newCharacterBuffer]] (empty) and
+ [[newCharacterBufferWithData]] (wrapping a [[String]])."
 by("Stéphane Épardaud")
-see(`class Buffer`,`function newCharacterBufferWithData`)
-shared class CharacterBuffer(String string) extends Buffer<Character>(){
-    
-    "The size of the given [[string]]."
-    shared actual Integer capacity = string.size;
-    
-    "Initially set to the [[string]] size."
-    shared variable actual Integer limit = string.size;
-    
-    "The current position index within this buffer. Starts at `0`
-     and grows with each [[get]] or [[put]] operation, until it reaches
-     the [[limit]]."
-    shared variable actual Integer position = 0;
+see(`class Buffer`,
+`function newByteBuffer`,
+`function newByteBufferWithData`)
+shared abstract class CharacterBuffer() extends Buffer<Character>(){
+	shared formal Array<Character> characters();
+	
+	"The platform-specific implementation object, if any."
+	shared formal Object? implementation;
+}
 
-    "Returns false. This buffer is read-only."
-    shared actual Boolean writable = false;
-
-    "Resets the [[position]] to `0` and the [[limit]] to the [[capacity]]. Use
-     this after reading to start reading the whole buffer again."
-    shared actual void clear() {
-        position = 0;
-        limit = capacity;
-    }
-
-    "This will and set its [[limit]] to the current [[position]],
-     and reset its [[position]] to `0`. This essentially means that you will be able
-     to read from the beginning of the buffer until the last object you read with [[get]]
-     while reading."
-    shared actual void flip() {
-        limit = position;
-        position = 0;
-    }
-
-    "Reads a [[Character]] from this buffer at the current [[position]].
-     Increases the [[position]] by `1`."
-    shared actual Character get() {
-        if(is Character c = string[position++]){
-            return c;
-        }
-        // FIXME: type
-        throw Exception("Buffer depleted");
-    }
-
-    "Not supported"
-    throws(`class Exception`,"Always")
-    shared actual void put(Character element) {
-        // FIXME: type
-        throw Exception("Buffer is read-only");
-    }
-    
-    "Not supported"
-    throws(`class Exception`,"Always")
-    shared actual void resize(Integer newSize, Boolean growLimit) {
-        // FIXME: type
-        throw Exception("Buffer is read-only");
-    }
+"Allocates a new empty [[CharacterBuffer]] with the given [[capacity]]."
+by("Stephen Crawley")
+see(`class CharacterBuffer`,
+    `function newCharacterBufferWithData`,
+    `class Buffer`)
+shared CharacterBuffer newCharacterBuffer(Integer capacity){
+    return CharacterBufferImpl(capacity);
 }
 
 "Allocates a new [[CharacterBuffer]] with the underlying [[data]]."
 by("Stéphane Épardaud")
 see(`class CharacterBuffer`)
 shared CharacterBuffer newCharacterBufferWithData(String data){
-    return CharacterBuffer(data);
+    return StringBackedCharacterBufferImpl(data);
 }

--- a/source/ceylon/io/buffer/impl/charbufferImpl.ceylon
+++ b/source/ceylon/io/buffer/impl/charbufferImpl.ceylon
@@ -1,0 +1,160 @@
+import ceylon.io.buffer { Buffer, CharacterBuffer, newCharacterBufferWithData }
+import java.nio { JavaCharBuffer=CharBuffer{ allocateJavaCharBuffer = allocate } }
+import java.lang { CharArray }
+
+"Represents a mutable [[Character]] [[Buffer]] backed by a Java CharBuffer."
+by("Stéphane Épardaud", "Stephen Crawley")
+shared class CharacterBufferImpl(Integer initialCapacity) extends CharacterBuffer(){
+	variable JavaCharBuffer buf = allocateJavaCharBuffer(initialCapacity);
+	shared JavaCharBuffer underlyingBuffer {
+		return buf;
+	}
+	
+	shared actual Integer capacity {
+		return buf.capacity();
+	}
+	shared actual Integer limit {
+		return buf.limit();
+	}
+	assign limit {
+		buf.limit(limit);
+	}
+	shared actual Integer position {
+		return buf.position();
+	}
+	assign position {
+		buf.position(position);
+	}
+	shared actual Character get() {
+		return buf.get();
+	}
+	shared actual void put(Character char) {
+		buf.put(char);
+	}
+	shared actual void clear() {
+		buf.clear();
+	}
+	shared actual void flip() {
+		buf.flip();
+	}
+	
+	shared actual void resize(Integer newSize, Boolean growLimit) {
+		if(newSize == capacity){
+			return;
+		}
+		if(newSize < 0){
+			// FIXME: type
+			throw;
+		}
+		JavaCharBuffer dest = allocateJavaCharBuffer(newSize);
+		// save our position and limit
+		value position = min([this.position, newSize]);
+		Integer limit;
+		if(newSize < capacity){
+			// shrink the limit
+			limit = min([this.limit, newSize]);
+		}else if(growLimit && this.limit == capacity){
+			// grow the limit if it was the max and we want that
+			limit = newSize;
+		}else{
+			// keep it if it was less than max
+			limit = this.limit;
+		}
+		// copy everything unless we shrink
+		value copyUntil = min([this.capacity, newSize]);
+		// prepare our limits for copying
+		buf.position(0);
+		buf.limit(copyUntil);
+		// copy
+		dest.put(buf);
+		// change buffer
+		buf = dest;
+		// now restore positions
+		buf.limit(limit);
+		buf.position(position);
+	}
+	
+	shared actual Array<Character> characters() {
+		value nativeArray = buf.array();
+		value size = nativeArray.size;
+		value result = arrayOfSize<Character>(size, ' ');
+		variable value i=0;
+		while (i<size) {
+			result.set(i, nativeArray.get(i));
+			i++;
+		}
+		return result;
+	}
+	
+	shared actual Object? implementation => underlyingBuffer;
+	
+}
+
+"Represents a read-only [[Character]] [[Buffer]] whose underlying data
+ is read from the given [[string]]. This buffer starts ready to be read,
+ with the [[position]] set to `0` and the [[limit]] set to size of the
+ given [[string]]."
+by("Stéphane Épardaud")
+see(`class Buffer`,`function newCharacterBufferWithData`)
+shared class StringBackedCharacterBufferImpl(String string) extends CharacterBuffer() {
+    
+    "The size of the given [[string]]."
+    shared actual Integer capacity = string.size;
+    
+    "Initially set to the [[string]] size."
+    shared variable actual Integer limit = string.size;
+    
+    "The current position index within this buffer. Starts at `0`
+     and grows with each [[get]] or [[put]] operation, until it reaches
+     the [[limit]]."
+    shared variable actual Integer position = 0;
+
+    "Returns false. This buffer is read-only."
+    shared actual Boolean writable = false;
+
+    "Resets the [[position]] to `0` and the [[limit]] to the [[capacity]]. Use
+     this after reading to start reading the whole buffer again."
+    shared actual void clear() {
+        position = 0;
+        limit = capacity;
+    }
+
+    "This will and set its [[limit]] to the current [[position]],
+     and reset its [[position]] to `0`. This essentially means that you will be able
+     to read from the beginning of the buffer until the last object you read with [[get]]
+     while reading."
+    shared actual void flip() {
+        limit = position;
+        position = 0;
+    }
+
+    "Reads a [[Character]] from this buffer at the current [[position]].
+     Increases the [[position]] by `1`."
+    shared actual Character get() {
+        if(is Character c = string[position++]){
+            return c;
+        }
+        // FIXME: type
+        throw Exception("Buffer depleted");
+    }
+
+    "Not supported"
+    throws(`class Exception`,"Always")
+    shared actual void put(Character element) {
+        // FIXME: type
+        throw Exception("Buffer is read-only");
+    }
+    
+    "Not supported"
+    throws(`class Exception`,"Always")
+    shared actual void resize(Integer newSize, Boolean growLimit) {
+        // FIXME: type
+        throw Exception("Buffer is read-only");
+    }
+    
+    shared actual Array<Character> characters() {
+        return Array<Character>(string.characters);
+    }
+    
+    shared actual Object? implementation => string;
+}

--- a/source/ceylon/io/buffer/impl/charbufferImpl.ceylon
+++ b/source/ceylon/io/buffer/impl/charbufferImpl.ceylon
@@ -1,12 +1,11 @@
 import ceylon.io.buffer { Buffer, CharacterBuffer, newCharacterBufferWithData }
-import java.nio { JavaCharBuffer=CharBuffer{ allocateJavaCharBuffer = allocate } }
-import java.lang { CharArray }
+import java.nio { JavaIntBuffer=IntBuffer{ allocateJavaIntBuffer = allocate } }
 
-"Represents a mutable [[Character]] [[Buffer]] backed by a Java CharBuffer."
+"Represents a mutable [[Character]] [[Buffer]] backed by a Java IntBuffer."
 by("Stéphane Épardaud", "Stephen Crawley")
 shared class CharacterBufferImpl(Integer initialCapacity) extends CharacterBuffer(){
-	variable JavaCharBuffer buf = allocateJavaCharBuffer(initialCapacity);
-	shared JavaCharBuffer underlyingBuffer {
+	variable JavaIntBuffer buf = allocateJavaIntBuffer(initialCapacity);
+	shared JavaIntBuffer underlyingBuffer {
 		return buf;
 	}
 	
@@ -26,10 +25,10 @@ shared class CharacterBufferImpl(Integer initialCapacity) extends CharacterBuffe
 		buf.position(position);
 	}
 	shared actual Character get() {
-		return buf.get();
+		return buf.get().character;
 	}
 	shared actual void put(Character char) {
-		buf.put(char);
+		buf.put(char.integer);
 	}
 	shared actual void clear() {
 		buf.clear();
@@ -46,7 +45,7 @@ shared class CharacterBufferImpl(Integer initialCapacity) extends CharacterBuffe
 			// FIXME: type
 			throw;
 		}
-		JavaCharBuffer dest = allocateJavaCharBuffer(newSize);
+		JavaIntBuffer dest = allocateJavaIntBuffer(newSize);
 		// save our position and limit
 		value position = min([this.position, newSize]);
 		Integer limit;
@@ -80,7 +79,7 @@ shared class CharacterBufferImpl(Integer initialCapacity) extends CharacterBuffe
 		value result = arrayOfSize<Character>(size, ' ');
 		variable value i=0;
 		while (i<size) {
-			result.set(i, nativeArray.get(i));
+			result.set(i, nativeArray.get(i).character);
 			i++;
 		}
 		return result;

--- a/test-source/test/ceylon/io/testBuffer.ceylon
+++ b/test-source/test/ceylon/io/testBuffer.ceylon
@@ -128,7 +128,7 @@ test void testByteBufferResize(){
 }
 
 
-test void testCharacterBuffer(){
+test void testStringBackedCharacterBuffer(){
     CharacterBuffer buffer = newCharacterBufferWithData("abcd");
     Character[] values = ['a', 'b', 'c', 'd'];
     testBuffer(buffer, values);

--- a/test-source/test/ceylon/io/testBuffer.ceylon
+++ b/test-source/test/ceylon/io/testBuffer.ceylon
@@ -1,6 +1,8 @@
 import ceylon.test { assertEquals, test }
 
-import ceylon.io.buffer { newByteBuffer, ByteBuffer, Buffer, newCharacterBufferWithData, CharacterBuffer }
+import ceylon.io.buffer { 
+	newByteBuffer, ByteBuffer, Buffer, 
+	newCharacterBufferWithData, CharacterBuffer, newCharacterBuffer }
 
 void testBuffer<T>(Buffer<T> buffer, T[] values) given T satisfies Object {
     // check initial state
@@ -132,4 +134,59 @@ test void testStringBackedCharacterBuffer(){
     CharacterBuffer buffer = newCharacterBufferWithData("abcd");
     Character[] values = ['a', 'b', 'c', 'd'];
     testBuffer(buffer, values);
+}
+
+test void testRegularCharacterBuffer(){
+	CharacterBuffer buffer = newCharacterBuffer(4);
+	Character[] values = ['a', 'b', 'c', 'd'];
+	testBuffer(buffer, values);
+}
+
+test void testCharacterBufferResize(){
+	CharacterBuffer buffer = newCharacterBuffer(4);
+	Character[] values = ['1', '2', '3', '4'];
+	for(Character val in values){
+		buffer.put(val);
+	}
+	
+	// flip it and eat a byte to get to position 1 
+	buffer.flip();
+	buffer.get();
+	assertEquals(1, buffer.position);
+	
+	// check initial state
+	assertEquals(4, buffer.capacity);
+	assertEquals(4, buffer.limit);
+	assertEquals(3, buffer.available);
+	assertEquals(1, buffer.position);
+	assertEquals(true, buffer.hasAvailable);
+	
+	// expand
+	buffer.resize(6);
+	// check expanded state
+	assertEquals(6, buffer.capacity);
+	assertEquals(4, buffer.limit);
+	assertEquals(3, buffer.available);
+	assertEquals(1, buffer.position);
+	assertEquals(true, buffer.hasAvailable);
+	
+	assertEquals('2', buffer.get());
+	assertEquals('3', buffer.get());
+	assertEquals('4', buffer.get());
+	
+	// flip it and eat a byte to get to position 1 
+	buffer.flip();
+	buffer.get();
+	assertEquals(1, buffer.position);
+	
+	// shrink
+	buffer.resize(2);
+	// check reduced state
+	assertEquals(2, buffer.capacity);
+	assertEquals(2, buffer.limit);
+	assertEquals(1, buffer.available);
+	assertEquals(1, buffer.position);
+	assertEquals(true, buffer.hasAvailable);
+	
+	assertEquals('2', buffer.get());
 }


### PR DESCRIPTION
This pull request turns CharacterBuffer into an abstract class, and makes the existing (immutable string-backed) class into an implementation class.  Then it adds a second (mutable) implementation class that uses a Java CharBuffer, and a new factory function.

This is a non-backwards-compatible change, but that's unavoidable if we want ByteBuffer and CharacterBuffer to be consistent.

There's one more thing I haven't done ... but I think we should do.  The 'newCharacterBufferWithData' function should really be changed to create a mutable buffer.  The function that creates an immutable buffer should be called something else; e.g. 'newCharacterBufferForString' ... or something like that.

(I could add that to this pull request, or do it in a followup pull request ...)

(You may also notice a striking similarity between the new CharacterBufferImpl class and ByteBufferImpl ... and the corresponding tests :-) )