### PR TITLE
fix arraylist first to array[0]

### DIFF
--- a/source/ceylon/collection/ArrayList.ceylon
+++ b/source/ceylon/collection/ArrayList.ceylon
@@ -267,7 +267,7 @@ shared class ArrayList<Element>
     
     shared actual Element? first {
         if (length>0) {
-             return array[length];
+             return array[0];
         }
         else {
             return null;

--- a/test-source/test/ceylon/collection/list.ceylon
+++ b/test-source/test/ceylon/collection/list.ceylon
@@ -156,6 +156,16 @@ shared test void testListConstructor(){
     assertEquals("b", list[1]);
 }
 
+shared test void testListFirstAndLast(){
+	List<String> listArray = ArrayList{"a", "b"};
+	assertEquals("a", listArray.first);
+	assertEquals("b", listArray.last);
+	
+	List<String> listLinked = LinkedList{"a", "b"};
+	assertEquals("a", listLinked.first);
+	assertEquals("b", listLinked.last);
+}
+
 "See [ceylon/ceylon-sdk#183](https://github.com/ceylon/ceylon-sdk/issues/183)."
 shared test void testLinkedListIssue183(){
     LinkedList<Integer> l = LinkedList<Integer>();


### PR DESCRIPTION
the implementation ArrayList.first was considering always array[length], it should be array[0]
