### PR TITLE
Remove use of sealed classes

### DIFF
--- a/source/ceylon/collection/LinkedList.ceylon
+++ b/source/ceylon/collection/LinkedList.ceylon
@@ -668,14 +668,6 @@ shared class LinkedList<Element>(elements = {})
 
     front => first;
     
-    shared actual Element[] sequence() {
-        value array = Array(this);
-        if (array.empty) {
-            return [];
-        }
-        else {
-            return ArraySequence(array);
-        }
-    }
-
+    shared actual Element[] sequence()
+        => Array(this).sequence();
 }

--- a/source/ceylon/time/internal/utils.ceylon
+++ b/source/ceylon/time/internal/utils.ceylon
@@ -35,7 +35,7 @@ shared [Value, Value]|Empty overlap<Value>([Value, Value] first, [Value, Value] 
        given Value satisfies Enumerable<Value>&Comparable<Value> {
     value ordered = sort(concatenate(first, second)).segment(1, 2); // take the middle two
 
-    if (Range(*first).containsEvery(ordered) && Range(*second).containsEvery(ordered)) {
+    if (range(*first).containsEvery(ordered) && range(*second).containsEvery(ordered)) {
         assert(exists start = ordered.first);
         assert(exists end = ordered.last);
 
@@ -60,7 +60,7 @@ shared [Value, Value]|Empty gap<Value>([Value, Value] first, [Value, Value] seco
        given Value satisfies Comparable<Value> & Enumerable<Value> {
 
     value ordered = sort(concatenate(first, second)).segment(1, 2); // take the middle two
-    if (Range(*first).containsEvery(ordered) && Range(*second).containsEvery(ordered)) {
+    if (range(*first).containsEvery(ordered) && range(*second).containsEvery(ordered)) {
         return empty;
     }
     


### PR DESCRIPTION
- two functions in `ceylon.time.internal` used `Range`; use `range` instead
- `LinkedList` used `ArraySequence` for `sequence()`; use `Array.sequence()` instead
  - the emptiness check can be removed, since `Array.sequence()` does it as well

Note that I currently can’t run the tests (both JVM and JS crash).
