### PR TITLE
Remove entries() use

### DIFF
--- a/source/ceylon/net/http/Header.ceylon
+++ b/source/ceylon/net/http/Header.ceylon
@@ -30,7 +30,7 @@ shared Header contentLength(String contentLength) => Header("Content-Length", co
 
 Header allowHeaders({Method*} methods) {
     StringBuilder sb = StringBuilder();
-    for (i -> method in entries(methods)) {
+    for (i -> method in methods.indexed) {
         if (i > 0) {
             sb.append(", ");
         }


### PR DESCRIPTION
`ceylon.language`'s toplevel `entries()` function was removed in ceylon/ceylon.language@50c2269; use `Iterable.indexed` instead.
