### PR TITLE
fix check for repeat/cycle

### DIFF
--- a/test-source/test/ceylon/collection/hashSet.ceylon
+++ b/test-source/test/ceylon/collection/hashSet.ceylon
@@ -11,17 +11,17 @@ import ceylon.test {
 class HashSetTest() satisfies MutableSetTests & InsertionOrderIterableTests {
 
     shared actual MutableSet<String> createSet({String*} strings) => HashSet { elements = strings; };
-    
+
     createCategory = createSet;
     createIterable = createSet;
 
     test shared void elementsAreKeptInOrder() {
         value set = HashSet { "A", "B", "C" };
+
         assertEquals(set.first, "A");
         assertEquals(set.rest.first, "B");
         assertEquals(set.rest.rest.first, "C");
     }
-    
 }
 
 class UnlinkedHashSetTest() satisfies MutableSetTests & HashOrderIterableTests {

--- a/test-source/test/ceylon/collection/mutableSet.ceylon
+++ b/test-source/test/ceylon/collection/mutableSet.ceylon
@@ -49,5 +49,16 @@ shared interface MutableSetTests satisfies SetTests {
         assertEquals(set, createSet {});
         assertFalse(set.remove("c"));
     }
+    
+    "This function is called by [[testCycle]] and [[testRepeat]]."
+    shared actual default void testCycleFunction(List<String?>(Integer)({String?*}) cycle) {
+        assertEquals(cycle(createIterable {})(0), []);
+        assertEquals(cycle(createIterable {})(1), []);
+        assertEquals(cycle(createIterable {})(-1), []);
+        assertEquals(cycle(createIterable {"a"})(1), ["a"]);
+        assertEquals(cycle(createIterable {"a", "b", "c"})(1), createIterable({"a", "b", "c"}).sequence());
+        assertEquals(cycle(createIterable {"a"})(2), ["a", "a"]);
+        assertEquals(cycle(createIterable {"a", "b", "c"})(3), ["a", "b", "c","a", "b", "c","a", "b", "c"]);
+    }
 
 }


### PR DESCRIPTION
So, the iterable tests were not considering that a HashSet implementation does not repeat its elements. I dont know if its the best way to fix this problem, if you have a better idea i would like to implement it.
