### PR TITLE
support unicode version test for java 8

### DIFF
--- a/test-source/test/ceylon/unicode/run.ceylon
+++ b/test-source/test/ceylon/unicode/run.ceylon
@@ -1,8 +1,19 @@
 import ceylon.test { ... }
 import ceylon.unicode { ... }
-
+import java.lang{
+    JSystem = System { 
+        jgetSystemProperty=getProperty 
+    }
+}
 test void testUnicodeVersion() {
-    assertEquals("6.0.0", unicodeVersion);
+    String jreVersion = jgetSystemProperty("java.version");
+    if (jreVersion.startsWith("1.7")) {
+        assertEquals("6.0.0", unicodeVersion);
+    } else if (jreVersion.startsWith("1.8")) {
+        assertEquals("6.2.0", unicodeVersion);
+    } else {
+        throw AssertionError("new unicode version supported and not tested yet");
+    }
 }
 
 test void testCharacterName() {


### PR DESCRIPTION
Unicode module implementation has a fixed version for java 7 and java 8, and the test just checked the version 7 unicode version, now I did the check for both versions based on current implementation.
P.S.: This test if failing if used with java 8.
