### PR TITLE
fix test to use same lineFeed as implementation

### DIFF
--- a/test-source/test/ceylon/html/serialization.ceylon
+++ b/test-source/test/ceylon/html/serialization.ceylon
@@ -89,7 +89,7 @@ void doTestExpectedOutput(
         {<Node->String>+} expectedResults,
         Boolean prettyPrint = false) {
     for (node->string in expectedResults) {
-        assertEquals(string.trimmed, serializeToString(node, prettyPrint));
+        assertEquals(string.trimmed.replace("\n", operatingSystem.newline), serializeToString(node, prettyPrint));
     }
 }
 


### PR DESCRIPTION
As windows has by default the operatingSystem.newline == \r\n then we need to change '\n' to operatingSystem.newline and make the test with same behavior as implementation.
P.S: Probably this is failing only in windows.
