### PR TITLE
Fix spelling mistakes and typing errors

### DIFF
--- a/source/ceylon/collection/LinkedList.ceylon
+++ b/source/ceylon/collection/LinkedList.ceylon
@@ -614,7 +614,7 @@ shared class LinkedList<Element>(elements = {})
      The default List implementation of firstIndexWhere + lastIndexWhere
      uses getFromFirst(index) instead of iterating over the list
      because for tuples and array sequences that's slightly faster.
-     It is of course desastrous for a linked list, where getFromFirst(index)
+     It is of course disastrous for a linked list, where getFromFirst(index)
      runs in O(index) time, which means that the default firstIndexWhere()
      and lastIndexWhere() run in O(size^2) time, so we refine it here.
      */

--- a/source/ceylon/dbc/connections.ceylon
+++ b/source/ceylon/dbc/connections.ceylon
@@ -7,14 +7,14 @@ import javax.sql {
 }
 
 "Obtain a connection source, that is, an instance of 
- `Connnection()`, for a given JDBC [[dataSource]]."
+ `Connection()`, for a given JDBC [[dataSource]]."
 see (`function newConnectionFromDataSourceWithCredentials`)
 shared Connection newConnectionFromDataSource
         (DataSource dataSource)()
         => dataSource.connection;
 
 "Obtain a connection source, that is, an instance of 
- `Connnection()`, for a given JDBC [[dataSource]], and
+ `Connection()`, for a given JDBC [[dataSource]], and
  given credentials."
 see (`function newConnectionFromDataSource`)
 shared Connection newConnectionFromDataSourceWithCredentials

--- a/source/ceylon/file/Path.ceylon
+++ b/source/ceylon/file/Path.ceylon
@@ -112,7 +112,7 @@ shared class Visitor() {
     
     "Called before visiting files and subdirectories
      of the given directory. If this method returns 
-     `false`, the files and subdirecties of the given 
+     `false`, the files and subdirectories of the given 
      directory will not be visited."
     shared default Boolean beforeDirectory(Directory dir) { return true; }
     

--- a/source/ceylon/html/Form.ceylon
+++ b/source/ceylon/html/Form.ceylon
@@ -1,6 +1,6 @@
 
 "Represents a collection of form-associated elements, some of
- which can representeditable values that can be submitted to
+ which can represent editable values that can be submitted to
  a server for processing.
  
  Technical details about this element can be found on the

--- a/source/ceylon/html/TextArea.ceylon
+++ b/source/ceylon/html/TextArea.ceylon
@@ -28,7 +28,7 @@ shared class TextArea(text = "", String? name = null,
         satisfies InlineElement & TextNode {
     
     if (exists wrapMode = wrap, wrapMode == hard) {
-        "The number os columns must be specified when wrap mode is `hard`"
+        "The number of columns must be specified when wrap mode is `hard`"
         assert (exists cols);
     }
 
@@ -38,7 +38,7 @@ shared class TextArea(text = "", String? name = null,
     shared Integer? rows;
 
     "Specifies the visible width of a text area.
-     **Must** be secified when [[TextArea.wrap]] is [[hard]]"
+     **Must** be specified when [[TextArea.wrap]] is [[hard]]"
     shared Integer? cols;
 
     "Specifies the maximum number of characters allowed."

--- a/source/ceylon/html/attributes.ceylon
+++ b/source/ceylon/html/attributes.ceylon
@@ -4,7 +4,7 @@
 shared alias NonstandardAttributes => [<String->Object>*];
 
 "Useful alias to indicate that a sequence of [[Entry]] can be
- used to add `data-` prefixed attributes tto he element."
+ used to add `data-` prefixed attributes to the element."
 shared alias DataContainer => [<String->Object>*];
 
 "Alias to represent a collection of CSS classes."

--- a/source/ceylon/io/base64.ceylon
+++ b/source/ceylon/io/base64.ceylon
@@ -51,10 +51,10 @@ abstract class AbstractBase64() satisfies Encoder & Decoder {
     "Returns characters table"
     shared formal [Character+] table;
 
-    "Retuns padding character"
+    "Returns padding character"
     shared Character pad = '=';
 
-    "Retuns index for ignored character"
+    "Returns index for ignored character"
     Integer ignoreCharIndex = 64;
 
     shared actual ByteBuffer encode( ByteBuffer input ) {

--- a/source/ceylon/io/buffer/buffer.ceylon
+++ b/source/ceylon/io/buffer/buffer.ceylon
@@ -1,7 +1,7 @@
 
 "Represents a memory buffer that can be read and written to with no
  allocation. The easiest way to get an idea of what a buffer is, is that
- it constists in an array of a given [[capacity]], a [[position]] index within the 
+ it consists in an array of a given [[capacity]], a [[position]] index within the 
  array, and a [[limit]] index.
  
  Typical operations on a buffer will be to fill it, which you do with [[put]]
@@ -62,7 +62,7 @@ shared abstract class Buffer<T>() satisfies Iterable<T> {
      the optional parameter [[growLimit]] is set to `true` (defaults to `false`),
      because when you are writing it makes sense to grow the limit, but when
      you are reading it usually does not, as growing a buffer does not generate
-     new meaningfull data."
+     new meaningful data."
     shared formal void resize(Integer newSize, Boolean growLimit = false);
 
     "Returns `true` if this buffer is writable, or `false` if it is read-only."

--- a/source/ceylon/math/decimal/implicitlyRounded.ceylon
+++ b/source/ceylon/math/decimal/implicitlyRounded.ceylon
@@ -1,5 +1,5 @@
-"Performs an arbitrary calcuation with the given rounding used 
- implicity when arithmetic operators are applied to `Decimal` 
+"Performs an arbitrary calculation with the given rounding used 
+ implicitly when arithmetic operators are applied to `Decimal` 
  operands.
  
  During a call to this method the `Decimal` operators

--- a/source/ceylon/math/decimal/parseDecimal.ceylon
+++ b/source/ceylon/math/decimal/parseDecimal.ceylon
@@ -5,7 +5,7 @@ import java.math {
     BigDecimal
 }
 
-"The `Decimal` repesented by the given string, or `null` 
+"The `Decimal` represented by the given string, or `null` 
  if the given string does not represent a `Decimal`."
 shared Decimal? parseDecimal(String str) {
     BigDecimal bd;

--- a/source/ceylon/math/whole/parseWhole.ceylon
+++ b/source/ceylon/math/whole/parseWhole.ceylon
@@ -5,7 +5,7 @@ import java.math {
     BigInteger
 }
 
-"The `Whole` repesented by the given string, or `null` 
+"The `Whole` represented by the given string, or `null` 
  if the given string does not represent a `Whole`."
 shared Whole? parseWhole(String num) {
     BigInteger bi;

--- a/source/ceylon/net/http/server/AsynchronousEndpoint.ceylon
+++ b/source/ceylon/net/http/server/AsynchronousEndpoint.ceylon
@@ -1,6 +1,6 @@
 import ceylon.net.http { Method }
-"Asynchronous web endpoint. Enpoint is executed 
- asynchronously. End of request proccessing must be 
+"Asynchronous web endpoint. Endpoint is executed 
+ asynchronously. End of request processing must be 
  signaled by calling `complete()`."
 by("Matej Lazar")
 shared class AsynchronousEndpoint(Matcher path, service, {Method*} acceptMethod) 

--- a/source/ceylon/net/http/server/Request.ceylon
+++ b/source/ceylon/net/http/server/Request.ceylon
@@ -6,11 +6,11 @@ import ceylon.net.http { Method }
 by("Matej Lazar")
 shared interface Request {
     
-    "Returns a single parameters wit given name. If there are more, the first one is returned.
+    "Returns a single parameters with given name. If there are more, the first one is returned.
      If `forseFormParsing` is false (default) and parameter with the same name exists in a query string, posted data is not parsed."
     shared formal String? parameter(String name, Boolean forseFormParsing = false);
     
-    "Returns all parameters wit given name.
+    "Returns all parameters with given name.
      If `forseFormParsing` is false (default) and parameter with the same name exists in a query string, posted data is not parsed.
      It is returned, only if it is already parsed."
     shared formal String[] parameters(String name, Boolean forseFormParsing = false);
@@ -22,7 +22,7 @@ shared interface Request {
     "Returns a single header with given name."
     shared formal String? header(String name);
     
-    "Returns all haaders with given name."
+    "Returns all headers with given name."
     shared formal String[] headers(String name);
     
     "Get the HTTP request method. {OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT}"

--- a/source/ceylon/net/http/server/endpoints/Options.ceylon
+++ b/source/ceylon/net/http/server/endpoints/Options.ceylon
@@ -1,5 +1,5 @@
 "outputBufferSize: size of output buffer
- readAttempts: abort reading after n unsucessful attempts"
+ readAttempts: abort reading after n unsuccessful attempts"
 by("Matej Lazar")
 shared class Options( 
         outputBufferSize = 8192,

--- a/source/ceylon/net/http/server/websocket/WebSocketChannel.ceylon
+++ b/source/ceylon/net/http/server/websocket/WebSocketChannel.ceylon
@@ -11,7 +11,7 @@ shared interface WebSocketChannel {
     "Return true if the session is open and connected"
     shared formal Boolean open();
 
-    "Return true if a close frame has been recieved"
+    "Return true if a close frame has been received"
     shared formal Boolean closeFrameReceived;
 
     shared formal void sendBinary(ByteBuffer binary);

--- a/source/ceylon/net/uri/PathSegment.ceylon
+++ b/source/ceylon/net/uri/PathSegment.ceylon
@@ -7,7 +7,7 @@ shared class PathSegment(String initialName, Parameter* initialParameters) {
     "The path segment name"
     shared variable String name = initialName;
     
-    "The path segment paramters"
+    "The path segment parameters"
     shared LinkedList<Parameter> parameters = LinkedList<Parameter>();
     
     for(Parameter p in initialParameters){

--- a/source/ceylon/process/Process.ceylon
+++ b/source/ceylon/process/Process.ceylon
@@ -78,7 +78,7 @@ shared Process createProcess(
          process."
         Input? input = null,
         "The destination for the standard output 
-         stream ofthe process, or `null` if the 
+         stream of the process, or `null` if the 
          standard output should be piped to the 
          current process."
         Output? output = null,

--- a/source/ceylon/promise/module.ceylon
+++ b/source/ceylon/promise/module.ceylon
@@ -5,7 +5,7 @@
  - the [[Completable]] interface forming the ground of promise, implemented primarily by the [[Promise]] interface.
  - the [[Promise]] interface, a promise is a [[Completable]] for a single value.
  - the [[Deferred]] type providing support for the [[Promise]] interface.
- - the [[Term]] interface for combining promises into a conjonction promise.
+ - the [[Term]] interface for combining promises into a conjunction promise.
 
  # Goal
  
@@ -30,7 +30,7 @@
  
  ## Deferred
  
- A [[Deferred]] object provides an implementation of the [[Promise]] interface and can be transitionned to a fulfillment
+ A [[Deferred]] object provides an implementation of the [[Promise]] interface and can be transitioned to a fulfillment
  or a reject resolution. It should remain private to the part of the code using it and only its promise should be visible.
 
  The [[Promise]] of a deferred can be retrieved with its `promise` field.
@@ -99,7 +99,7 @@
  
  ## Feeding with a promise
  
- Deferred can be transitionned with a promise instead of a value:
+ Deferred can be transitioned with a promise instead of a value:
  
      Deferred<String> deferred1 = getDeferred1();
      Deferred<String> deferred2 = getDeferred2();

--- a/source/ceylon/test/TestListener.ceylon
+++ b/source/ceylon/test/TestListener.ceylon
@@ -48,7 +48,7 @@ shared interface TestListener {
         "The event object."
         TestIgnoreEvent event) {}
     
-    "Called when a test will not be run, because some error has occured.
+    "Called when a test will not be run, because some error has occurred.
      For example a invalid test function signature."
     shared default void testError(
         "The event object."

--- a/source/ceylon/test/TestResult.ceylon
+++ b/source/ceylon/test/TestResult.ceylon
@@ -11,7 +11,7 @@ shared class TestResult(description, state, exception = null, elapsedTime = 0) {
     "The exception thrown during this test, if any."
     shared Throwable? exception;
     
-    "The total elapsed time in miliseconds."
+    "The total elapsed time in milliseconds."
     shared Integer elapsedTime;
     
     shared actual String string => "``description`` - ``state```` (exception exists) then " (`` exception?.string else "" ``)" else "" ``";

--- a/source/ceylon/test/TestRunResult.ceylon
+++ b/source/ceylon/test/TestRunResult.ceylon
@@ -25,7 +25,7 @@ shared interface TestRunResult {
     "The time in milliseconds when the test run finished."
     shared formal Integer endTime;
     
-    "The total elapsed time in miliseconds."
+    "The total elapsed time in milliseconds."
     shared formal Integer elapsedTime;
     
     "The detailed results of each test."

--- a/source/ceylon/time/DateRange.ceylon
+++ b/source/ceylon/time/DateRange.ceylon
@@ -8,7 +8,7 @@ import ceylon.time.internal { _gap = gap, _overlap = overlap }
  * Easy way to recover [[Duration]]
  * Recover the overlap between [[DateRange]] types
  * Recover the gap between [[DateRange]] types
- * Allows cutomized way to iterate as navigate between values by [[UnitOfDate]] cases
+ * Allows customized way to iterate as navigate between values by [[UnitOfDate]] cases
  "
 see(`interface Range`)
 shared class DateRange( from, to, step = days ) satisfies Range<Date, UnitOfDate> {

--- a/source/ceylon/time/DateTimeRange.ceylon
+++ b/source/ceylon/time/DateTimeRange.ceylon
@@ -8,7 +8,7 @@ import ceylon.time.internal { _gap = gap, _overlap = overlap }
  * Easy way to recover [[Duration]]
  * Recover the overlap between [[DateTimeRange]] types
  * Recover the gap between [[DateTimeRange]] types
- * Allows cutomized way to iterate as navigate between values by [[UnitOfDate]] or [[UnitOfTime]] cases
+ * Allows customized way to iterate as navigate between values by [[UnitOfDate]] or [[UnitOfTime]] cases
  "
 shared class DateTimeRange( from, to, step = milliseconds ) satisfies Range<DateTime, UnitOfDate|UnitOfTime> {
 

--- a/source/ceylon/time/TimeRange.ceylon
+++ b/source/ceylon/time/TimeRange.ceylon
@@ -8,7 +8,7 @@ import ceylon.time.internal { _gap = gap, _overlap = overlap }
  * Easy way to recover [[Duration]]
  * Recover the overlap between [[TimeRange]] types
  * Recover the gap between [[TimeRange]] types
- * Allows cutomized way to iterate as navigate between values by [[UnitOfTime]] cases
+ * Allows customized way to iterate as navigate between values by [[UnitOfTime]] cases
  "
 see(`interface Range`)
 shared class TimeRange( from, to, step = milliseconds ) satisfies Range<Time, UnitOfTime> {

--- a/source/ceylon/time/base/DayOfWeek.ceylon
+++ b/source/ceylon/time/base/DayOfWeek.ceylon
@@ -56,49 +56,49 @@ shared DayOfWeek? parseDayOfWeek(String dayOfWeek){
     return null;
 }
 
-"_Sunday_ is the day of the week that follows Saturday and preceeds Monday."
+"_Sunday_ is the day of the week that follows Saturday and precedes Monday."
 shared object sunday extends DayOfWeek(0) {
     shared actual String string = "sunday";
     shared actual DayOfWeek predecessor => saturday;
     shared actual DayOfWeek successor => monday;
 }
 
-"_Monday_ is the day of the week that follows Sunday and preceeds Tuesday."
+"_Monday_ is the day of the week that follows Sunday and precedes Tuesday."
 shared object monday extends DayOfWeek(1) {
     shared actual String string = "monday";
     shared actual DayOfWeek predecessor => sunday;
     shared actual DayOfWeek successor => tuesday;
 }
 
-"_Tuesday_ is the day of the week that follows Monday and preceeds Wednesday."
+"_Tuesday_ is the day of the week that follows Monday and precedes Wednesday."
 shared object tuesday extends DayOfWeek(2) {
     shared actual String string = "tuesday";
     shared actual DayOfWeek predecessor => monday;
     shared actual DayOfWeek successor => wednesday;
 }
 
-"_Wednesday_ is the day of the week that follows Tuesday and preceeds Thursday."
+"_Wednesday_ is the day of the week that follows Tuesday and precedes Thursday."
 shared object wednesday extends DayOfWeek(3) {
     shared actual String string = "wednesday";
     shared actual DayOfWeek predecessor => tuesday;
     shared actual DayOfWeek successor => thursday;
 }
 
-"_Thursday_ is the day of the week that follows Wednesday and preceeds Friday."
+"_Thursday_ is the day of the week that follows Wednesday and precedes Friday."
 shared object thursday extends DayOfWeek(4) {
     shared actual String string = "thursday";
     shared actual DayOfWeek predecessor => wednesday;
     shared actual DayOfWeek successor => friday;
 }
 
-"_Friday_ is the day of the week that follows Thursday and preceeds Saturday."
+"_Friday_ is the day of the week that follows Thursday and precedes Saturday."
 shared object friday extends DayOfWeek(5) {
     shared actual String string = "friday";
     shared actual DayOfWeek predecessor => thursday;
     shared actual DayOfWeek successor => saturday;
 }
 
-"_Saturday_ is the day of the week that follows Friday and preceeds Sunday."
+"_Saturday_ is the day of the week that follows Friday and precedes Sunday."
 shared object saturday extends DayOfWeek(6) {
     shared actual String string = "saturday";
     shared actual DayOfWeek predecessor => friday;

--- a/source/ceylon/time/base/Month.ceylon
+++ b/source/ceylon/time/base/Month.ceylon
@@ -74,7 +74,7 @@ Integer[] firstDayOfMonth = [1, 32, 60, 91, 121, 152, 182, 213, 244, 274, 305, 3
  value of the [[Month]] (i.e. 1=[[january]], 2=[[february]], ... 12=[[december]])
  Any invalid values will throw an [[AssertionError]].
  
- If the imput value is a [[Month]], the input value is returned as is."
+ If the input value is a [[Month]], the input value is returned as is."
 shared Month monthOf(Integer|Month month){
     switch (month)
     case (is Month) { return month; }
@@ -142,7 +142,7 @@ shared object august extends Month(gregorian.august) {
     shared actual Month successor => september;
 }
 
-"September. The nineth month of a gregorian calendar system."
+"September. The ninth month of a gregorian calendar system."
 shared object september extends Month(gregorian.september) {
     shared actual String string = "september";
     shared actual Month predecessor => august;
@@ -163,7 +163,7 @@ shared object november extends Month(gregorian.november) {
     shared actual Month successor => december;
 }
 
-"December. The twelveth (last) month of a gregorian calendar system."
+"December. The twelfth (last) month of a gregorian calendar system."
 shared object december extends Month(gregorian.december) {
     shared actual String string = "december";
     shared actual Month predecessor => november;

--- a/source/ceylon/time/chronology/Chronology.ceylon
+++ b/source/ceylon/time/chronology/Chronology.ceylon
@@ -90,7 +90,7 @@ shared object gregorian extends GregorianCalendar() {
     shared Integer december = 12;
 
     "Gregorian leap year rule states that every fourth year
-     is a leap year except cenury years not divisible by 400."
+     is a leap year except century years not divisible by 400."
     shared actual Boolean leapYear(Integer year) {
         return (year % 100 == 0) then year % 400 == 0
                                  else year % 4 == 0;
@@ -154,7 +154,7 @@ shared object gregorian extends GregorianCalendar() {
         return [year, month, day];
     }
 
-    "Retunrs the month number of the gregorian calendar from the fixed date value."
+    "Returns the month number of the gregorian calendar from the fixed date value."
     shared Integer monthFrom(Integer date){
         return dateFrom(date)[1];
     }

--- a/source/ceylon/time/internal/GregorianDate.ceylon
+++ b/source/ceylon/time/internal/GregorianDate.ceylon
@@ -22,14 +22,14 @@ shared class GregorianDate( Integer dayOfEra )
     "Returns _day of year_ value of this gregorian date."
     shared actual Integer dayOfYear => month.firstDayOfYear( leapYear ) + day - 1;
 
-    "Returns gregorian date immediately preceeding this date.\n
+    "Returns gregorian date immediately preceding this date.\n
      For successor its used the lowest unit of date, this way we can benefit
-     from maximum precision. In this case the sucessor is the current value minus 1 day."
+     from maximum precision. In this case the successor is the current value minus 1 day."
     shared actual Date predecessor => minusDays( 1 );
 
     "Returns gregorian date immediately succeeding this date.\n
      For successor its used the lowest unit of date, this way we can benefit
-     from maximum precision. In this case the sucessor is the current value plus 1 day."
+     from maximum precision. In this case the successor is the current value plus 1 day."
     shared actual Date successor => plusDays( 1 );
 
     "Returns current day of the week."

--- a/source/ceylon/time/internal/GregorianDateTime.ceylon
+++ b/source/ceylon/time/internal/GregorianDateTime.ceylon
@@ -14,7 +14,7 @@ shared class GregorianDateTime( date, time )
     "Returns [[Time]] representation of current _date and time_."
     shared actual Time time;
 
-    "Comparing [[DateTime]] is based on [[Date]] and [[Time]] comparision."
+    "Comparing [[DateTime]] is based on [[Date]] and [[Time]] comparison."
     shared actual Comparison compare(DateTime other) {
         return date != other.date then date <=> other.date
                                   else time <=> other.time;

--- a/source/ceylon/time/internal/GregorianZonedDateTime.ceylon
+++ b/source/ceylon/time/internal/GregorianZonedDateTime.ceylon
@@ -258,7 +258,7 @@ shared class GregorianZonedDateTime(instant, timeZone = tz.system) satisfies Zon
      **Note:** The resulting  [[ZoneDateTime]] can be affected by Daylight Saving Time."
     shared actual ZoneDateTime predecessor => adjust( instant.dateTime(timeZone).predecessor );
 
-    "For sucessor its used the lowest unit of time, this way we can benefit
+    "For successor its used the lowest unit of time, this way we can benefit
      from maximum precision. In this case the successor is the current value plus 1 millisecond.
 
      **Note:** The resulting  [[ZoneDateTime]] can be affected by Daylight Saving Time."

--- a/source/ceylon/time/internal/TimeOfDay.ceylon
+++ b/source/ceylon/time/internal/TimeOfDay.ceylon
@@ -37,7 +37,7 @@ shared class TimeOfDay(millisecondsOfDay) satisfies Time {
     shared actual Time predecessor => minusMilliseconds(1);
 
     "For successor its used the lowest unit of time, this way we can benefit
-     from maximum precision. In this case the sucessor is the current value plus 1 millisecond."
+     from maximum precision. In this case the successor is the current value plus 1 millisecond."
     shared actual Time successor => plusMilliseconds(1);
 
     "Returns ISO-8601 formatted String representation of this _time of day_.\n
@@ -51,7 +51,7 @@ shared class TimeOfDay(millisecondsOfDay) satisfies Time {
     shared actual Time plusHours(Integer hours) => plusMilliseconds( hours * ms.perHour );
 
     "Subtracts specified number of hours from this time of day 
-     and returns the resul as new time of day."
+     and returns the result as new time of day."
     shared actual Time minusHours(Integer hours) => minusMilliseconds( hours * ms.perHour );
 
     "Adds specified number of minutes to this time of day 

--- a/source/ceylon/time/timezone/TimeZone.ceylon
+++ b/source/ceylon/time/timezone/TimeZone.ceylon
@@ -64,7 +64,7 @@ shared object timeZone {
         shared actual String string  = "Z";
 	}
 
-    "Parses input string and returns approprate time zone.
+    "Parses input string and returns appropriate time zone.
      Currently it accepts only ISO-8601 time zone offset patterns:
      &plusmn;`[hh]:[mm]`, &plusmn;`[hh][mm]`, and &plusmn;`[hh]`.
  

--- a/source/ceylon/time/timezone/parseTimeZone.ceylon
+++ b/source/ceylon/time/timezone/parseTimeZone.ceylon
@@ -1,6 +1,6 @@
 import ceylon.time.base { ms = milliseconds }
 
-"Represents the problem that occured while parsing. It can be recovered from _message_ field"
+"Represents the problem that occurred while parsing. It can be recovered from _message_ field"
 shared class ParserError( message ) {
     shared String message;
 
@@ -40,7 +40,7 @@ shared TimeZone|ParserError parseTimeZone( String offset ) {
 }
 
 
-"Represents each elelment or the end of the parser"
+"Represents each element or the end of the parser"
 abstract class Input() of Chunk | EOF {}
 
 "Represents each character"
@@ -64,7 +64,7 @@ abstract class EOF() of eof extends Input() {}
 "Singleton implementation to represent the end of the parser"
 object eof extends EOF() {}
 
-"All states avaiable for the parser"
+"All states available for the parser"
 abstract class State() of Initial | Zulu | Sign | Hours | Minutes | Final | Error | Colon {
 
     "Each state is responsible to check if the next state is valid and call it"
@@ -188,7 +188,7 @@ class Colon( Integer sign, Integer hours ) extends State() {
     }
 }
 
-"Rrepresents the parser successfully finished"
+"Represents the parser successfully finished"
 class Final( Integer sign = 1, Integer hours = 0, Integer minutes = 0 ) extends State() {
     shared actual State next(Input character) => this;
     shared Integer evaluate() {

--- a/source/com/redhat/ceylon/test/TapLoggingListener.ceylon
+++ b/source/com/redhat/ceylon/test/TapLoggingListener.ceylon
@@ -18,9 +18,9 @@ import ceylon.test {
  
  * `elapsed` for the [[elapsed time|TestResult.elapsedTime]], in milliseconds (not for ignored tests)
  * `reason` for the [[ignore reason|IgnoreAnnotation.reason]], if present
- * `severity` for the [[state|TestResult.state]], one of `failure` or `error` (omitted for sucessful tests)
+ * `severity` for the [[state|TestResult.state]], one of `failure` or `error` (omitted for successful tests)
  * `actual`, `expected` if the [[exception|TestResult.exception]] is an [[AssertionComparisonError]]
- * `exception` for the exception’s stacktrace if it exists, but isn’t an [[AssertionComparisonError]].
+ * `exception` for the exception’s stack trace if it exists, but isn’t an [[AssertionComparisonError]].
  
  ### Example
  


### PR DESCRIPTION
Found with

``` bash
find source -name '*.ceylon' -exec grep '^\(    \)*\( \|"\)[^ ]' {} + > tmp
```

to find text that's most likely documentation (starts with 4n + 1 spaces), and then

``` bash
hunspell tmp
```

to spellcheck the text.

See also ceylon/ceylon.language#512 and ceylon/ceylon.language@28e2b25.
