### PR TITLE
Fix spelling mistake in parameter

### DIFF
--- a/source/ceylon/net/http/server/Request.ceylon
+++ b/source/ceylon/net/http/server/Request.ceylon
@@ -7,13 +7,13 @@ by("Matej Lazar")
 shared interface Request {
     
     "Returns a single parameters with given name. If there are more, the first one is returned.
-     If `forseFormParsing` is false (default) and parameter with the same name exists in a query string, posted data is not parsed."
-    shared formal String? parameter(String name, Boolean forseFormParsing = false);
+     If `forceFormParsing` is false (default) and parameter with the same name exists in a query string, posted data is not parsed."
+    shared formal String? parameter(String name, Boolean forceFormParsing = false);
     
     "Returns all parameters with given name.
-     If `forseFormParsing` is false (default) and parameter with the same name exists in a query string, posted data is not parsed.
+     If `forceFormParsing` is false (default) and parameter with the same name exists in a query string, posted data is not parsed.
      It is returned, only if it is already parsed."
-    shared formal String[] parameters(String name, Boolean forseFormParsing = false);
+    shared formal String[] parameters(String name, Boolean forceFormParsing = false);
 
     shared formal UploadedFile? file(String name);
 

--- a/source/ceylon/net/http/server/internal/RequestImpl.ceylon
+++ b/source/ceylon/net/http/server/internal/RequestImpl.ceylon
@@ -154,7 +154,7 @@ shared class RequestImpl(HttpServerExchange exchange, FormParserFactory formPars
         return mergedParams.sequence();
     }
 
-    shared actual String? parameter(String name, Boolean forseFormParsing) {
+    shared actual String? parameter(String name, Boolean forceFormParsing) {
         value params = parameters(name);
         if (nonempty params) {
             return params.first;


### PR DESCRIPTION
forseFormParsing → forceFormParsing

Done with the following command:

``` bash
find -name '*.ceylon' \
    -and -exec grep -q 'forseFormParsing' {} \; \
    -and -exec sed -i 's forseFormParsing forceFormParsing ' {} +
```

I didn’t do this in #263 because it potentially breaks source-code compatibility (named arguments).
