### PR TITLE
fix message for assertEquals

### DIFF
--- a/source/ceylon/test/assertions.ceylon
+++ b/source/ceylon/test/assertions.ceylon
@@ -94,7 +94,7 @@ shared void assertEquals(
     if (!compare(actual, expected)) {
         value actualText = nullSafeString(actual);
         value expectedText = nullSafeString(expected);
-        value exceptionMessage = "`` message else "assertion failed" ``: expected <``actualText``> but was <``expectedText``>";
+        value exceptionMessage = "`` message else "assertion failed" ``: expected <``expectedText``> but was <``actualText``>";
         throw AssertionComparisonError(exceptionMessage, actualText, expectedText);
     }
 }

--- a/test-source/test/ceylon/test/suite/asserting.ceylon
+++ b/test-source/test/ceylon/test/suite/asserting.ceylon
@@ -84,31 +84,31 @@ shared void testAssertEquals() {
     
     assertThatException(()=>assertEquals(true, false, "wops")).
             hasType(`AssertionComparisonError`).
-            hasMessage("wops: expected <true> but was <false>");
+            hasMessage("wops: expected <false> but was <true>");
     
     assertThatException(()=>assertEquals(1, 2)).
             hasType(`AssertionComparisonError`).
-            hasMessage("assertion failed: expected <1> but was <2>");
+            hasMessage("assertion failed: expected <2> but was <1>");
     
     assertThatException(()=>assertEquals(1.1, 2.2)).
             hasType(`AssertionComparisonError`).
-            hasMessage("assertion failed: expected <1.1> but was <2.2>");
+            hasMessage("assertion failed: expected <2.2> but was <1.1>");
     
     assertThatException(()=>assertEquals('f', 'b')).
             hasType(`AssertionComparisonError`).
-            hasMessage("assertion failed: expected <f> but was <b>");
+            hasMessage("assertion failed: expected <b> but was <f>");
     
     assertThatException(()=>assertEquals("foo", "bar")).
             hasType(`AssertionComparisonError`).
-            hasMessage("assertion failed: expected <foo> but was <bar>");
+            hasMessage("assertion failed: expected <bar> but was <foo>");
     
     assertThatException(()=>assertEquals([1, 2, 3], [3, 2, 1])).
             hasType(`AssertionComparisonError`).
-            hasMessage("assertion failed: expected <[1, 2, 3]> but was <[3, 2, 1]>");
+            hasMessage("assertion failed: expected <[3, 2, 1]> but was <[1, 2, 3]>");
     
     assertThatException(()=>assertEquals({1, 2, 3}, [])).
             hasType(`AssertionComparisonError`).
-            hasMessage("assertion failed: expected <{ 1, 2, 3 }> but was <[]>");
+            hasMessage("assertion failed: expected <[]> but was <{ 1, 2, 3 }>");
 }
 
 test


### PR DESCRIPTION
The signature of assertEquals method is:

``` ceylon
shared void assertEquals(
    "The actual value to be checked."
    Anything actual,
    "The expected value."
    Anything expected,
....
```

so, for this code:

``` ceylon
test shared void run() {

    value actual = 1;
    value expected = 2;

    assertEquals(actual, expected);
}
```

i Would expect the message something like:
`assertion failed: expected <2> but was <1>` instead i think the message is wrong saying: ````assertion failed: expected <1> but was <2>` 

I believe it was just a mistake using the arguments is wrong order...
