### PR TITLE
remove initial path because createTestFile does return absolutePath

### DIFF
--- a/test-source/test/ceylon/net/server.ceylon
+++ b/test-source/test/ceylon/net/server.ceylon
@@ -123,7 +123,7 @@ test void testServer() {
             or endsWith(".txt");
         },
         AsynchronousEndpoint {
-            service => serveStaticFile("/", fileMapper);
+            service => serveStaticFile("", fileMapper);
             path = startsWith("/filemapper");
         },
         Endpoint { 


### PR DESCRIPTION
this test wasnt working for windows because it was always adding `/` to file path. I dont believe its necessary as createTempFile always return absolutePath.

```
Starting on 127.0.0.1:8080
Debug: XNIO version 3.1.0.CR7 
Debug: XNIO NIO Implementation Version 3.1.0.CR7 
Httpd started.
Received contents: application/x-www-form-urlencoded
Making request to Ceylon server...
Received message: Hello Ceylon!
Debug: Blocking request failed HttpServerExchange{ GET /filemapper} java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C:\trabalho\ceylon\ceylon-sdk-diego\lazydog.txt
Httpd stopped.
Exception in thread "Thread-2" ceylon.language.Exception "Failed to read contents"
    at ceylon.net.http.client.Response.readEntityBody$priv$(Response.ceylon:210)
    at ceylon.net.http.client.Response.getContents(Response.ceylon:187)
    at test.ceylon.net.fileMapperTest_.fileMapperTest(server.ceylon:283)
    at test.ceylon.net.testServer_$1onStartedExecuteTest_.onStartedExecuteTest(server.ceylon:186)
    at test.ceylon.net.testServer_$1.$call$(server.ceylon:218)
    at ceylon.net.http.server.internal.DefaultServer.notifyListeners$priv$(DefaultServer.ceylon:208)
    at ceylon.net.http.server.internal.DefaultServer.start$canonical$(DefaultServer.ceylon:178)
    at ceylon.net.http.server.internal.DefaultServer.start(DefaultServer.ceylon:122)
    at ceylon.net.http.server.internal.DefaultServer$1httpd_.run(DefaultServer.ceylon:189)
    at java.lang.Thread.run(Thread.java:724)

```
