### PR TITLE
fix for new resourceByPath relative load of resources

### DIFF
--- a/source/ceylon/locale/Locale.ceylon
+++ b/source/ceylon/locale/Locale.ceylon
@@ -39,7 +39,7 @@ shared Locale currentLocale {
 }
 
 shared Locale? locale(String tag) {
-    value filePath = "ceylon/locale/" + tag + ".txt";
+    value filePath = tag + ".txt";
     if (exists resource = 
             localeModule.resourceByPath(filePath)) {
         Iterator<String> lines = resource.textContent()


### PR DESCRIPTION
A few days ago there was a change to resourceByPath, now it accepts relative and absolute loads. This change only worked for me in JVM but i do believe it should work same way in both plataforms. Im not sure if JS plataform has resourceByPath implemented.

Just to sync this adding @quintesse and @gavinking
