### PR TITLE
Better implementation of LinkedList.collect()

### DIFF
--- a/source/ceylon/collection/LinkedList.ceylon
+++ b/source/ceylon/collection/LinkedList.ceylon
@@ -611,12 +611,12 @@ shared class LinkedList<Element>(elements = {})
     }
     
     /*
-     The default List implementation of firstIndexWhere + lastIndexWhere
-     uses getFromFirst(index) instead of iterating over the list
+     The default List implementations of firstIndexWhere, lastIndexWhere
+     and collect use getFromFirst(index) instead of iterating over the list
      because for tuples and array sequences that's slightly faster.
      It is of course disastrous for a linked list, where getFromFirst(index)
-     runs in O(index) time, which means that the default firstIndexWhere()
-     and lastIndexWhere() run in O(size^2) time, so we refine it here.
+     runs in O(index) time, which means that the default firstIndexWhere(),
+     lastIndexWhere() and collect() run in O(size^2) time, so we refine it here.
      */
     
     shared actual Integer? firstIndexWhere(
@@ -649,6 +649,11 @@ shared class LinkedList<Element>(elements = {})
         }
         return result;
     }
+    
+    shared actual Result[] collect<Result>(
+            "The transformation applied to the elements."
+            Result collecting(Element element))
+            => [for (element in this) collecting(element)];
 
     first => head?.element;
 


### PR DESCRIPTION
`List.collect()` uses `getFromFirst(index)` instead of iterating the list, resulting in O(n²) runtime for lists that don’t offer cheap index-based access. By overriding `collect()` in `LinkedList`, we can go back to O(n) runtime, vastly improving performance.

I have tested three different implementations against a `LinkedList` from current `master` (7b6c7f0c70ecf2e95718731fe2c3b09145963c4e):

``` ceylon
import ceylon.collection {
    ArrayList,
    LinkedList,
    MutableList
}

class MyLinkedList_ArraySequence<Element>(elements = {}) extends LinkedList<Element>(elements) {
    "The initial elements of the list."
    {Element*} elements;

    shared actual Result[] collect<Result>(Result collecting(Element element))
            => Array { for (element in this) collecting(element) }.sequence();
}

class MyLinkedList_Comprehension<Element>(elements = {}) extends LinkedList<Element>(elements) {
    "The initial elements of the list."
    {Element*} elements;

    shared actual Result[] collect<Result>(Result collecting(Element element))
            => [for (element in this) collecting(element)];
}

class MyLinkedList_ArrayOfSize<Element>(elements = {}) extends LinkedList<Element>(elements) {
    "The initial elements of the list."
    {Element*} elements;

    shared actual Result[] collect<Result>(Result collecting(Element element)) {
        if (!empty) {
            assert (exists first = first);
            value array = arrayOfSize(size, collecting(first));
            variable value i = 1;
            for (element in rest) {
                array.set(i++, collecting(element));
            }
            return array.sequence();
        } else {
            return [];
        }
    }
}

class S(shared String s) {}

Integer testPerformance(MutableList<S>({S*}) listConstructor, Integer listSize) {
    variable value t = 0;
    for (i in 1..10) {
        value list = listConstructor({ for (j in 1:listSize) S(j.string) });
        value tStart = system.nanoseconds;
        list.collect((S s) => parseInteger(s.s));
        value tEnd = system.nanoseconds;
        t += tEnd - tStart;
    }
    return t;
}

void run() {
    for (printFunction in { noop, print }) { // first run for warm-up
        for (listSize in { 1_000, 10_000, 100_000 }) {
            printFunction(
                "``listSize`` elements:
                 ArrayList:                    ``testPerformance(({S*} elements) => ArrayList { elements = elements; }, listSize)``ns
                 LinkedList:                   ``testPerformance(LinkedList<S>, listSize)``ns
                 LinkedList, Array.sequence(): ``testPerformance(MyLinkedList_ArraySequence<S>, listSize)``ns
                 LinkedList, comprehension:    ``testPerformance(MyLinkedList_Comprehension<S>, listSize)``ns
                 LinkedList, arrayOfSize():    ``testPerformance(MyLinkedList_ArrayOfSize<S>, listSize)``ns"
            );
        }
    }
}
```

(The `MyLinkedList_ArrayOfSize` implementation had to be altered a little; a `LinkedList` version would use the unshared `head`.)

```
1000 elements:
ArrayList:                    2045339ns
LinkedList:                   16831863ns
LinkedList, Array.sequence(): 1929069ns
LinkedList, comprehension:    1903268ns
LinkedList, arrayOfSize():    1968027ns
10000 elements:
ArrayList:                    23150491ns
LinkedList:                   1904315964ns
LinkedList, Array.sequence(): 24806347ns
LinkedList, comprehension:    26867767ns
LinkedList, arrayOfSize():    22684744ns
100000 elements:
ArrayList:                    294192537ns
LinkedList:                   328916162989ns
LinkedList, Array.sequence(): 333778547ns
LinkedList, comprehension:    328901486ns
LinkedList, arrayOfSize():    336785355ns
```

As can be seen, they all vastly improve the performance of the `collect` inherited from `List` – for 100k elements, by a factor of 1000! – and all have roughly the same performance. As their relative speed varied between test runs (the `ArrayOfSize` version was slightly faster in an earlier run), I chose the easiest and most obvious implementation; however, I believe an even faster implementation ought to be possible in the future: see #284.

This finally fixes the performance after [this commit](https://github.com/ceylon/ceylon.language/commit/81918e7ff58bc2682a0dd4ca9f197b9887097ca3#commitcomment-6771484) broke it. (“I can fix it tomorrow”… yeah, kinda ;) )

CC @gavinking, @quintesse. See also #247 and the commits + issues mentioned in the commit message.
