### PR TITLE
Collection wrappers improvements

### DIFF
--- a/source/ceylon/interop/java/CeylonCollection.ceylon
+++ b/source/ceylon/interop/java/CeylonCollection.ceylon
@@ -1,0 +1,28 @@
+import java.util {
+    JCollection=Collection,
+    ArrayList
+}
+
+"A Ceylon [[Collection]] that wraps a [[java.util::Collection]]."
+shared
+class CeylonCollection<out Element>
+        (JCollection<out Element> collection)
+        satisfies Collection<Element> {
+
+    shared actual default
+    Integer size
+        =>  collection.size();
+
+    shared actual default
+    Boolean contains(Object element)
+        =>  collection.contains(element);
+
+    shared actual default
+    Collection<Element> clone()
+        =>  CeylonCollection(ArrayList(collection));
+
+    shared actual default
+    Iterator<Element> iterator()
+        =>  CeylonIterator(collection.iterator());
+
+}

--- a/source/ceylon/interop/java/CeylonList.ceylon
+++ b/source/ceylon/interop/java/CeylonList.ceylon
@@ -8,7 +8,7 @@ import java.util {
 }
 
 "A Ceylon [[List]] that wraps a [[java.util::List]]."
-shared class CeylonList<Element>(JList<out Element> list) 
+shared class CeylonList<out Element>(JList<out Element> list)
         satisfies List<Element> 
         given Element satisfies Object {
     

--- a/source/ceylon/interop/java/CeylonList.ceylon
+++ b/source/ceylon/interop/java/CeylonList.ceylon
@@ -9,6 +9,7 @@ import java.util {
 
 "A Ceylon [[List]] that wraps a [[java.util::List]]."
 shared class CeylonList<out Element>(JList<out Element> list)
+        extends CeylonCollection<Element>(list)
         satisfies List<Element> 
         given Element satisfies Object {
     

--- a/source/ceylon/interop/java/CeylonList.ceylon
+++ b/source/ceylon/interop/java/CeylonList.ceylon
@@ -16,6 +16,8 @@ shared class CeylonList<out Element>(JList<out Element> list)
     
     size => list.size();
     
+    contains(Object element) => list.contains(element);
+
     shared actual Integer? lastIndex {
         value size = this.size;
         return size>0 then size-1;

--- a/source/ceylon/interop/java/CeylonMap.ceylon
+++ b/source/ceylon/interop/java/CeylonMap.ceylon
@@ -17,6 +17,8 @@ shared class CeylonMap<out Key, out Item>(JMap<out Key, out Item> map)
 
     keys => CeylonSet(map.keySet());
 
+    items => CeylonCollection(map.values());
+
     iterator() 
             => CeylonIterable(map.entrySet())
                 .map((entry) => entry.key->entry.\ivalue)

--- a/source/ceylon/interop/java/CeylonMap.ceylon
+++ b/source/ceylon/interop/java/CeylonMap.ceylon
@@ -13,6 +13,10 @@ shared class CeylonMap<out Key, out Item>(JMap<out Key, out Item> map)
     
     defines(Object key) => map.containsKey(key);
     
+    size => map.size();
+
+    keys => CeylonSet(map.keySet());
+
     iterator() 
             => CeylonIterable(map.entrySet())
                 .map((entry) => entry.key->entry.\ivalue)

--- a/source/ceylon/interop/java/CeylonMap.ceylon
+++ b/source/ceylon/interop/java/CeylonMap.ceylon
@@ -4,7 +4,7 @@ import java.util {
 }
 
 "A Ceylon [[Map]] that wraps a [[java.util::Map]]."
-shared class CeylonMap<Key, Item>(JMap<out Key, out Item> map) 
+shared class CeylonMap<out Key, out Item>(JMap<out Key, out Item> map)
         satisfies Map<Key, Item> 
         given Key satisfies Object 
         given Item satisfies Object {

--- a/source/ceylon/interop/java/CeylonSet.ceylon
+++ b/source/ceylon/interop/java/CeylonSet.ceylon
@@ -4,7 +4,7 @@ import java.util {
 }
 
 "A Ceylon [[Set]] that wraps a [[java.util::Set]]."
-shared class CeylonSet<Element>(JSet<out Element> set) 
+shared class CeylonSet<out Element>(JSet<out Element> set)
         satisfies Set<Element> 
         given Element satisfies Object {
     

--- a/source/ceylon/interop/java/CeylonSet.ceylon
+++ b/source/ceylon/interop/java/CeylonSet.ceylon
@@ -10,6 +10,10 @@ shared class CeylonSet<out Element>(JSet<out Element> set)
     
     iterator() => CeylonIterator(set.iterator());
     
+    contains(Object element) => set.contains(element);
+
+    size => set.size();
+
     shared actual Set<Element> 
             complement<Other>(Set<Other> set)
             given Other satisfies Object {

--- a/source/ceylon/interop/java/CeylonSet.ceylon
+++ b/source/ceylon/interop/java/CeylonSet.ceylon
@@ -5,6 +5,7 @@ import java.util {
 
 "A Ceylon [[Set]] that wraps a [[java.util::Set]]."
 shared class CeylonSet<out Element>(JSet<out Element> set)
+        extends CeylonCollection<Element>(set)
         satisfies Set<Element> 
         given Element satisfies Object {
     

--- a/source/ceylon/interop/java/JavaComparator.ceylon
+++ b/source/ceylon/interop/java/JavaComparator.ceylon
@@ -1,0 +1,47 @@
+import java.util {
+    JComparator=Comparator
+}
+
+"A Java [[java.util::Comparator]] that wraps a function
+ returning [[Comparison]]. The given [[compareElements]] function will
+ be used to compare null values if [[Element]] covers [[Null]]. Otherwise,
+ nulls will be ordered according to the [[nulls]] parameter."
+shared
+class JavaComparator<Element>(compareElements, nulls=smaller)
+        satisfies JComparator<Element> {
+
+    Comparison compareElements(Element x, Element y);
+
+    "[[smaller]] to consider null less than non-null, or [[larger]] to consider
+     null greater than non-null."
+    \Ismaller|\Ilarger nulls;
+
+    function toInteger(Comparison comparison)
+        =>  switch (comparison)
+            case (equal)    0
+            case (larger)   1
+            case (smaller) -1;
+
+    Comparison ceylonCompare(Element? first, Element? second)
+        =>  if (is Element first, is Element second) then
+                // Element may actually support Null
+                compareElements(first, second)
+            else if (exists first) then
+                if (exists second) then
+                    compareElements(first, second)
+                else
+                    nulls.reversed // second is null
+            else if (exists second) then
+                nulls // first is null
+            else
+                equal; // both are null
+
+    shared actual
+    Integer compare(Element? first, Element? second)
+        =>  toInteger(ceylonCompare(first, second));
+
+    shared actual
+    Boolean equals(Object that)
+        =>  (super of Basic).equals(that);
+
+}

--- a/source/ceylon/interop/java/JavaMap.ceylon
+++ b/source/ceylon/interop/java/JavaMap.ceylon
@@ -41,8 +41,12 @@ class JavaEntry<K,V>(K->V entry)
             return false;
         }
     }
-    
-    shared actual Integer hash => 31*key.hash+\ivalue.hash;
+
+    shared actual Integer hash
+        // Calculate hash per java.util.Map.Entry contract, and
+        // defeat bit shifting described in
+        // https://github.com/ceylon/ceylon-compiler/issues/1334
+        =>  key.hash.xor(\ivalue.hash).and(#ffffffff);
 }
 
 "A Java [[java.util::Map]] that wraps a Ceylon [[Map]]. This 


### PR DESCRIPTION
The most important item here is the addition of `CeylonSet.contains()`, which might be nice to have! There are a few other cleanups as well.

I also added `CeylonCollection`, which is useful since it's not uncommon for Java APIs to return `JCollection`s. One immediate use is in `CeylonMap.items`.

Finally, I also have a `JavaComparator` class that was necessary in my jl4c.guava project, but I'm not sure how much you want the interop package to grow. I'll add it to this PR if you think it would be useful. [It's](https://github.com/jvasileff/jl4c-guava/blob/master/source/com/vasileff/jl4c/guava/collect/JavaComparator.ceylon) basically:

```ceylon
class JavaComparator<Element>(comparator, nulls=smaller)
        satisfies JComparator<Element> {

    Comparison comparator(Element x, Element y);
    \Ismaller|\Ilarger nulls;

    ...
}
```
