### PR TITLE
Delete correct element from linked list in HashSet

### DIFF
--- a/source/ceylon/collection/HashSet.ceylon
+++ b/source/ceylon/collection/HashSet.ceylon
@@ -215,7 +215,7 @@ shared class HashSet<Element>
             if (exists rest,
                 rest.element == element) {
                 cell.rest = rest.rest;
-                deleteCell(cell);
+                deleteCell(rest);
                 length--;
                 return true;
             }
@@ -244,7 +244,7 @@ shared class HashSet<Element>
     iterator() => stability==linked 
             then LinkedCellIterator(head)
             else StoreIterator(store);
-    
+
     shared actual Integer count(Boolean selecting(Element element)) {
         variable Integer count = 0;
         variable Integer index = 0;


### PR DESCRIPTION
When deleting buckets from the linked list used to maintain stability in
HashSets with stability=linked, we often deleted the predecessor to the target
not the target itself. Ouch.

Signed-off-by: Casey Dahlin <casey.dahlin@gmail.com>