### PR TITLE
ceylon.html improvements

### DIFF
--- a/source/ceylon/html/A.ceylon
+++ b/source/ceylon/html/A.ceylon
@@ -47,7 +47,7 @@ shared class A(text = "", href = "#", target = null, download = null,
      It is purely advisory."
     shared String? type;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("a");
 

--- a/source/ceylon/html/Blockquote.ceylon
+++ b/source/ceylon/html/Blockquote.ceylon
@@ -19,7 +19,7 @@ shared class Blockquote(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<BlockElement|{BlockElement*}|Snippet<BlockElement>|Null>*} children;
+    shared actual {<String|BlockElement|{String|BlockElement*}|Snippet<BlockElement>|Null>*} children;
 
     tag = Tag("blockquote");
 

--- a/source/ceylon/html/Body.ceylon
+++ b/source/ceylon/html/Body.ceylon
@@ -16,10 +16,10 @@ shared class Body(String? id = null, CssClass classNames = [],
         extends BaseElement(id, classNames, style, accessKey, contextMenu,
             dir, draggable, dropZone, inert, hidden, lang, spellcheck,
             tabIndex, title, translate, aria, nonstandardAttributes, data)
-        satisfies ParentNode<BlockElement|Script> {
+        satisfies ParentNode<BlockOrInline|Script> {
 
-    shared actual {<BlockElement|Null|Script|Snippet<BlockElement>|
-            {BlockElement*}|{Script*}>*} children;
+    shared actual {<String|BlockOrInline|Null|Script|Snippet<BlockOrInline>|
+            {String|BlockOrInline*}|{Script*}>*} children;
 
     tag = Tag("body");
 

--- a/source/ceylon/html/Button.ceylon
+++ b/source/ceylon/html/Button.ceylon
@@ -29,7 +29,7 @@ shared class Button(text = "", type = button,
     "Specifies the type of button."
     shared ButtonType type;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("button");
 

--- a/source/ceylon/html/Div.ceylon
+++ b/source/ceylon/html/Div.ceylon
@@ -40,7 +40,7 @@ shared class Div(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
+    shared actual {<String|BlockOrInline|{String|BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
 
     tag = Tag("div");
 

--- a/source/ceylon/html/FieldSet.ceylon
+++ b/source/ceylon/html/FieldSet.ceylon
@@ -50,7 +50,7 @@ shared class Legend(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("legend");
 

--- a/source/ceylon/html/FieldSet.ceylon
+++ b/source/ceylon/html/FieldSet.ceylon
@@ -21,7 +21,7 @@ shared class FieldSet(legend = null, String? id = null, CssClass classNames = []
 
     shared Legend? legend;
 
-    shared actual {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
+    shared actual {<String|BlockOrInline|{String|BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
 
     tag = Tag("fieldset");
 

--- a/source/ceylon/html/Form.ceylon
+++ b/source/ceylon/html/Form.ceylon
@@ -56,7 +56,7 @@ shared class Form(action, method = "", acceptCharset = null,
      that is received after submitting the form."
     shared String? target; // TODO enumerated type? look at A.target
 
-    shared actual {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
+    shared actual {<String|BlockOrInline|{String|BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
 
     tag = Tag("form");
 

--- a/source/ceylon/html/Form.ceylon
+++ b/source/ceylon/html/Form.ceylon
@@ -22,7 +22,7 @@ shared class Form(action, method = "", acceptCharset = null,
         extends BaseElement(id, classNames, style, accessKey, contextMenu,
             dir, draggable, dropZone, inert, hidden, lang, spellcheck,
             tabIndex, title, translate, aria, nonstandardAttributes, data)
-        satisfies BlockElement & ParentNode<BlockElement> {
+        satisfies BlockElement & ParentNode<BlockOrInline> {
 
     "Specifies where to send the form-data
      when a form is submitted."
@@ -56,7 +56,7 @@ shared class Form(action, method = "", acceptCharset = null,
      that is received after submitting the form."
     shared String? target; // TODO enumerated type? look at A.target
 
-    shared actual {<BlockElement|{BlockElement*}|Snippet<BlockElement>|Null>*} children;
+    shared actual {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
 
     tag = Tag("form");
 

--- a/source/ceylon/html/Heading.ceylon
+++ b/source/ceylon/html/Heading.ceylon
@@ -26,7 +26,7 @@ shared abstract class Heading(text = "", String? id = null, CssClass classNames 
 
     shared formal Integer level;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag => Tag("h``level``");
 

--- a/source/ceylon/html/Heading.ceylon
+++ b/source/ceylon/html/Heading.ceylon
@@ -45,7 +45,7 @@ shared class H1(String text = "", String? id = null, CssClass classNames = [],
             Boolean? translate = null, Aria? aria = null,
             NonstandardAttributes nonstandardAttributes = empty,
             DataContainer data = empty,
-            {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children = {})
+            {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children = {})
         extends Heading(text, id, classNames, style, accessKey, contextMenu,
             dir, draggable, dropZone, inert, hidden, lang, spellcheck,
             tabIndex, title, translate, aria, nonstandardAttributes, data, children) {
@@ -65,7 +65,7 @@ shared class H2(String text = "", String? id = null, CssClass classNames = [],
             Boolean? translate = null, Aria? aria = null,
             NonstandardAttributes nonstandardAttributes = empty,
             DataContainer data = empty,
-            {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children = {})
+            {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children = {})
         extends Heading(text, id, classNames, style, accessKey, contextMenu,
             dir, draggable, dropZone, inert, hidden, lang, spellcheck,
             tabIndex, title, translate, aria, nonstandardAttributes, data, children) {
@@ -85,7 +85,7 @@ shared class H3(String text = "", String? id = null, CssClass classNames = [],
             Boolean? translate = null, Aria? aria = null,
             NonstandardAttributes nonstandardAttributes = empty,
             DataContainer data = empty,
-            {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children = {})
+            {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children = {})
         extends Heading(text, id, classNames, style, accessKey, contextMenu,
             dir, draggable, dropZone, inert, hidden, lang, spellcheck,
             tabIndex, title, translate, aria, nonstandardAttributes, data, children) {
@@ -105,7 +105,7 @@ shared class H4(String text = "", String? id = null, CssClass classNames = [],
             Boolean? translate = null, Aria? aria = null,
             NonstandardAttributes nonstandardAttributes = empty,
             DataContainer data = empty,
-            {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children = {})
+            {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children = {})
         extends Heading(text, id, classNames, style, accessKey, contextMenu,
             dir, draggable, dropZone, inert, hidden, lang, spellcheck,
             tabIndex, title, translate, aria, nonstandardAttributes, data, children) {
@@ -125,7 +125,7 @@ shared class H5(String text = "", String? id = null, CssClass classNames = [],
             Boolean? translate = null, Aria? aria = null,
             NonstandardAttributes nonstandardAttributes = empty,
             DataContainer data = empty,
-            {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children = {})
+            {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children = {})
         extends Heading(text, id, classNames, style, accessKey, contextMenu,
             dir, draggable, dropZone, inert, hidden, lang, spellcheck,
             tabIndex, title, translate, aria, nonstandardAttributes, data, children) {
@@ -145,7 +145,7 @@ shared class H6(String text = "", String? id = null, CssClass classNames = [],
             Boolean? translate = null, Aria? aria = null,
             NonstandardAttributes nonstandardAttributes = empty,
             DataContainer data = empty,
-            {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children = {})
+            {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children = {})
         extends Heading(text, id, classNames, style, accessKey, contextMenu,
             dir, draggable, dropZone, inert, hidden, lang, spellcheck,
             tabIndex, title, translate, aria, nonstandardAttributes, data, children) {

--- a/source/ceylon/html/Label.ceylon
+++ b/source/ceylon/html/Label.ceylon
@@ -30,7 +30,7 @@ shared class Label(text = "", forControl = null, form = null,
     "Specifies one or more forms the label belongs to."
     shared String? form;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("label");
 

--- a/source/ceylon/html/ListElements.ceylon
+++ b/source/ceylon/html/ListElements.ceylon
@@ -74,7 +74,7 @@ shared class Li(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;    
 
-    shared actual {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
+    shared actual {<String|BlockOrInline|{String|BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
 
     tag = Tag("li");
 
@@ -131,7 +131,7 @@ shared class Dt(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;    
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("dt");
 
@@ -161,7 +161,7 @@ shared class Dd(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;    
 
-    shared actual {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
+    shared actual {<String|BlockOrInline|{String|BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
 
     tag = Tag("dd");
 

--- a/source/ceylon/html/Node.ceylon
+++ b/source/ceylon/html/Node.ceylon
@@ -25,7 +25,7 @@ shared interface ParentNode<out Child>
         satisfies Node
             given Child satisfies Node {
 
-    shared formal {<Child|{Child*}|Snippet<Child>|Null>*} children;
+    shared formal {<Child|String|{Child|String*}|Snippet<Child>|Null>*} children;
 
 }
 

--- a/source/ceylon/html/P.ceylon
+++ b/source/ceylon/html/P.ceylon
@@ -19,7 +19,7 @@ shared class P(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("p");
 

--- a/source/ceylon/html/Pre.ceylon
+++ b/source/ceylon/html/Pre.ceylon
@@ -21,7 +21,7 @@ shared class Pre(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("pre");
 

--- a/source/ceylon/html/Sectioning.ceylon
+++ b/source/ceylon/html/Sectioning.ceylon
@@ -20,7 +20,7 @@ shared class Article(String? id = null, CssClass classNames = [],
             tabIndex, title, translate, aria, nonstandardAttributes, data)
         satisfies BlockElement & ParentNode<BlockOrInline> {
 
-    shared actual {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
+    shared actual {<String|BlockOrInline|{String|BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
 
     tag = Tag("article");
 
@@ -48,7 +48,7 @@ shared class Aside(String? id = null, CssClass classNames = [],
             tabIndex, title, translate, aria, nonstandardAttributes, data)
         satisfies BlockElement & ParentNode<BlockOrInline> {
 
-    shared actual {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
+    shared actual {<String|BlockOrInline|{String|BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
 
     tag = Tag("aside");
 
@@ -76,7 +76,7 @@ shared class Header(String? id = null, CssClass classNames = [],
             tabIndex, title, translate, aria, nonstandardAttributes, data)
         satisfies BlockElement & ParentNode<BlockOrInline> {
     
-    shared actual {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
+    shared actual {<String|BlockOrInline|{String|BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
     
     tag = Tag("header");
     
@@ -104,7 +104,7 @@ shared class Footer(String? id = null, CssClass classNames = [],
             tabIndex, title, translate, aria, nonstandardAttributes, data)
         satisfies BlockElement & ParentNode<BlockOrInline> {
     
-    shared actual {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
+    shared actual {<String|BlockOrInline|{String|BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
     
     tag = Tag("footer");
     
@@ -131,7 +131,7 @@ shared class Nav(String? id = null, CssClass classNames = [],
             tabIndex, title, translate, aria, nonstandardAttributes, data)
         satisfies BlockElement & ParentNode<BlockOrInline> {
     
-    shared actual {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
+    shared actual {<String|BlockOrInline|{String|BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
     
     tag = Tag("nav");
     
@@ -160,7 +160,7 @@ shared class Section(String? id = null, CssClass classNames = [],
             tabIndex, title, translate, aria, nonstandardAttributes, data)
         satisfies BlockElement & ParentNode<BlockOrInline> {
     
-    shared actual {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
+    shared actual {<String|BlockOrInline|{String|BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
     
     tag = Tag("section");
     

--- a/source/ceylon/html/Select.ceylon
+++ b/source/ceylon/html/Select.ceylon
@@ -96,7 +96,7 @@ shared class OptionGroup(text = "",
 
     tag = Tag("optgroup");
 
-    shared actual {<Option|{Option*}|Snippet<Option>|Null>*} children;
+    shared actual {<String|Option|{String|Option*}|Snippet<Option>|Null>*} children;
 
     shared actual default [<String->Object>*] attributes {
         value attrs = AttributeSequenceBuilder();

--- a/source/ceylon/html/Span.ceylon
+++ b/source/ceylon/html/Span.ceylon
@@ -37,7 +37,7 @@ shared class Span(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("span");
 

--- a/source/ceylon/html/Table.ceylon
+++ b/source/ceylon/html/Table.ceylon
@@ -128,7 +128,7 @@ shared class Th(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
+    shared actual {<String|BlockOrInline|{String|BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
 
     tag = Tag("th");
 
@@ -155,7 +155,7 @@ shared class Td(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
+    shared actual {<String|BlockOrInline|{String|BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
 
     tag = Tag("td");
 

--- a/source/ceylon/html/TextElements.ceylon
+++ b/source/ceylon/html/TextElements.ceylon
@@ -23,7 +23,7 @@ shared class Abbr(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("abbr");
 
@@ -54,7 +54,7 @@ shared class B(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("b");
 
@@ -84,7 +84,7 @@ shared class Cite(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("cite");
 
@@ -112,7 +112,7 @@ shared class Code(text = "", String? id = null, CssClass classNames = [],
     
     shared actual String text;
     
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
     
     tag = Tag("code");
     
@@ -142,7 +142,7 @@ shared class Del(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("del");
 
@@ -173,7 +173,7 @@ shared class Dfn(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("dfn");
 
@@ -201,7 +201,7 @@ shared class Em(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("em");
 
@@ -230,7 +230,7 @@ shared class I(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("i");
 
@@ -260,7 +260,7 @@ shared class Ins(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("ins");
 
@@ -289,7 +289,7 @@ shared class Kbd(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("kbd");
 
@@ -318,7 +318,7 @@ shared class Mark(text = "", String? id = null, CssClass classNames = [],
 
     shared actual String text;
 
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
 
     tag = Tag("mark");
 
@@ -346,7 +346,7 @@ shared class Q(text = "", String? id = null, CssClass classNames = [],
     
     shared actual String text;
     
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
     
     tag = Tag("q");
     
@@ -374,7 +374,7 @@ shared class S(text = "", String? id = null, CssClass classNames = [],
     
     shared actual String text;
     
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
     
     tag = Tag("s");
     
@@ -402,7 +402,7 @@ shared class Samp(text = "", String? id = null, CssClass classNames = [],
     
     shared actual String text;
     
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
     
     tag = Tag("samp");
     
@@ -431,7 +431,7 @@ shared class Small(text = "", String? id = null, CssClass classNames = [],
     
     shared actual String text;
     
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
     
     tag = Tag("small");
     
@@ -459,7 +459,7 @@ shared class Strong(text = "", String? id = null, CssClass classNames = [],
     
     shared actual String text;
     
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
     
     tag = Tag("strong");
     
@@ -487,7 +487,7 @@ shared class Sub(text = "", String? id = null, CssClass classNames = [],
     
     shared actual String text;
     
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
     
     tag = Tag("sub");
     
@@ -515,7 +515,7 @@ shared class Sup(text = "", String? id = null, CssClass classNames = [],
     
     shared actual String text;
     
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
     
     tag = Tag("sup");
     
@@ -545,7 +545,7 @@ shared class U(text = "", String? id = null, CssClass classNames = [],
     
     shared actual String text;
     
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
     
     tag = Tag("u");
     
@@ -575,7 +575,7 @@ shared class Var(text = "", String? id = null, CssClass classNames = [],
     
     shared actual String text;
     
-    shared actual {<InlineElement|{InlineElement*}|Snippet<InlineElement>|Null>*} children;
+    shared actual {<String|InlineElement|{String|InlineElement*}|Snippet<InlineElement>|Null>*} children;
     
     tag = Tag("var");
     

--- a/source/ceylon/html/serializer/EscapableType.ceylon
+++ b/source/ceylon/html/serializer/EscapableType.ceylon
@@ -4,8 +4,8 @@ import ceylon.collection {
 }
 
 interface EscapableType of
-        name, attributeValue,
-        text, rawText, escapableRawText {
+        name | attributeValue |
+        text | rawText | escapableRawText {
 
     shared formal
     Map<Character, String> entities;

--- a/source/ceylon/html/serializer/EscapableType.ceylon
+++ b/source/ceylon/html/serializer/EscapableType.ceylon
@@ -37,12 +37,10 @@ object attributeValue satisfies EscapableType {
         '&' -> "&amp;"});
 }
 
-// "Normal elements can have text, character references, other elements,
-//      and comments, but the text must not contain the character "<" (U+003C)
-//      or an ambiguous ampersand. Some normal elements also have yet more
-//      restrictions on what content they are allowed to hold, beyond the
-//      restrictions imposed by the content model and those described in this
-//      paragraph. Those restrictions are described below.
+"From <http://www.w3.org/TR/html5/syntax.html#elements-0>
+ > Normal elements can have text, character references, other elements,
+ and comments, but the text must not contain the character \"<\" (U+003C)
+ or an ambiguous ampersand."
 object text satisfies EscapableType {
     shared actual
     Map<Character, String> entities = unmodifiableMap(HashMap {
@@ -50,21 +48,34 @@ object text satisfies EscapableType {
         '&' -> "&amp;"});
 }
 
-// http://www.w3.org/TR/html5/scripting-1.html#restrictions-for-contents-of-script-elements
-// http://www.w3.org/TR/html5/syntax.html#cdata-rcdata-restrictions
-// "Raw text elements can have text, though it has restrictions described below"
+"From <http://www.w3.org/TR/html5/syntax.html#elements-0>
+ > Raw text elements can have text, though it has
+ restrictions described below
+
+ From <http://www.w3.org/TR/html5/syntax.html#cdata-rcdata-restrictions>
+ > The text in raw text and escapable raw text elements must not contain
+ any occurrences of the string \"&lt;/\" (U+003C LESS-THAN SIGN, U+002F SOLIDUS)
+ followed by characters that case-insensitively match the tag name of the element
+ followed by one of \"tab\" (U+0009), \"LF\" (U+000A), \"FF\" (U+000C),
+ \"CR\" (U+000D), U+0020 SPACE, \">\" (U+003E), or \"/\" (U+002F).
+
+ From <http://www.w3.org/TR/html5/scripting-1.html#restrictions-for-contents-of-script-elements>
+ > Note: The easiest and safest way to avoid the rather strange restrictions
+ described in this section is to always escape \"&lt;!--\" as \"&lt;\\!--\",
+ \"<script\" as \"&lt;\\script\", and \"&lt;/script\" as \"&lt;\\/script\"
+ when these sequences appear in literals in scripts..."
 object rawText satisfies EscapableType {
     shared actual
     Map<Character, String> entities = emptyMap;
 }
 
-// http://www.w3.org/TR/html5/syntax.html#cdata-rcdata-restrictions
-// "Escapable raw text elements can have text and character references,
-//      but the text must not contain an ambiguous ampersand. There are
-//      also further restrictions described below"
-// We will treat escapableRawText as text, and escape '<', thereby
-// avoiding the "further restrictions".
-// TODO: <textarea> and <title> actually cannot contain elements; open elements are parsed as text
+"From <http://www.w3.org/TR/html5/syntax.html#elements-0>
+ > Escapable raw text elements can have text and character references, but
+ the text must not contain an ambiguous ampersand. There are also further
+ restrictions described below.
+
+ We will treat escapableRawText as text, and escape '<', thereby
+ avoiding the \"further restrictions\"."
 object escapableRawText satisfies EscapableType {
     shared actual
     Map<Character, String> entities = unmodifiableMap(HashMap {

--- a/source/ceylon/html/serializer/EscapableType.ceylon
+++ b/source/ceylon/html/serializer/EscapableType.ceylon
@@ -1,0 +1,82 @@
+import ceylon.collection {
+    HashMap,
+    unmodifiableMap
+}
+
+interface EscapableType of
+        name, attributeValue,
+        text, rawText, escapableRawText {
+
+    shared formal
+    Map<Character, String> entities;
+}
+
+object name satisfies EscapableType {
+    shared actual
+    Map<Character, String> entities = emptyMap;
+
+    // http://www.w3.org/TR/REC-xml/#NT-Name
+    // much more liberal than the HTML5 spec, but more realistic
+    shared
+    Boolean isValid(String name)
+        =>  if (exists first = name.first,
+                xmlNameStartCharRanges.any((range)
+                    =>  range.containsElement(first.integer)),
+                name.rest.every((c)
+                    =>  xmlNameCharRanges.any((range)
+                        =>  range.containsElement(c.integer))))
+            then true
+            else false;
+}
+
+object attributeValue satisfies EscapableType {
+    shared actual
+    Map<Character, String> entities = unmodifiableMap(HashMap {
+        '\'' -> "&#39;",
+        '"' -> "&quot;",
+        '&' -> "&amp;"});
+}
+
+// "Normal elements can have text, character references, other elements,
+//      and comments, but the text must not contain the character "<" (U+003C)
+//      or an ambiguous ampersand. Some normal elements also have yet more
+//      restrictions on what content they are allowed to hold, beyond the
+//      restrictions imposed by the content model and those described in this
+//      paragraph. Those restrictions are described below.
+object text satisfies EscapableType {
+    shared actual
+    Map<Character, String> entities = unmodifiableMap(HashMap {
+        '<' -> "&lt;",
+        '&' -> "&amp;"});
+}
+
+// http://www.w3.org/TR/html5/scripting-1.html#restrictions-for-contents-of-script-elements
+// http://www.w3.org/TR/html5/syntax.html#cdata-rcdata-restrictions
+// "Raw text elements can have text, though it has restrictions described below"
+object rawText satisfies EscapableType {
+    shared actual
+    Map<Character, String> entities = emptyMap;
+}
+
+// http://www.w3.org/TR/html5/syntax.html#cdata-rcdata-restrictions
+// "Escapable raw text elements can have text and character references,
+//      but the text must not contain an ambiguous ampersand. There are
+//      also further restrictions described below"
+// We will treat escapableRawText as text, and escape '<', thereby
+// avoiding the "further restrictions".
+// TODO: <textarea> and <title> actually cannot contain elements; open elements are parsed as text
+object escapableRawText satisfies EscapableType {
+    shared actual
+    Map<Character, String> entities = unmodifiableMap(HashMap {
+        '<' -> "&lt;",
+        '&' -> "&amp;"});
+}
+
+\Itext | \IrawText | \IescapableRawText typeForElement(String element)
+    =>  let (lower = element.lowercased)
+        if (rawTextElements.contains(lower)) then
+            rawText
+        else if (escapableRawTextElements.contains(lower)) then
+            escapableRawText
+        else
+            text;

--- a/source/ceylon/html/serializer/HtmlSerializer.ceylon
+++ b/source/ceylon/html/serializer/HtmlSerializer.ceylon
@@ -1,0 +1,104 @@
+import ceylon.collection {
+    Stack,
+    LinkedList
+}
+
+class HtmlSerializer(Anything(String) print, Boolean prettyPrint, Boolean escapeNonAscii=false) {
+
+    variable
+    [String, {<String->Object>*}]? cachedStartElement = null;
+
+    Stack<String> elementStack = LinkedList<String>();
+
+    StringBuilder bufferedText = StringBuilder();
+
+    function escape(String raw, EscapableType type)
+        =>  htmlEscape(raw, type, escapeNonAscii, elementStack.top);
+
+    void flushText() {
+        // we're strict for now;
+        // not allowing text outside of an enclosing element
+        if (!bufferedText.empty) {
+            assert(exists current = elementStack.top);
+            value type = typeForElement(current);
+            print(escape(bufferedText.string, type));
+            bufferedText.clear();
+        }
+    }
+
+    void flushStartElement(Boolean end = false) {
+        if (exists [elementName, attributes] = cachedStartElement) {
+            print("<");
+            print(escape(elementName, package.name));
+            for (name->val in attributes) {
+                print(" "
+                    + escape(name, package.name)
+                    + "=\""
+                    + escape(val.string, attributeValue)
+                    + "\"");
+            }
+            if (end) {
+                if (voidElements.contains(elementName.lowercased)) {
+                    print(">");
+                }
+                else {
+                    // only void and foreign elements can be self-closing,
+                    // so we'll output the complete end tag
+                    //http://www.w3.org/TR/html5/syntax.html#start-tags
+                    print("></" + escape(elementName, package.name) + ">");
+                }
+            } else {
+                print(">");
+                elementStack.push(elementName);
+            }
+        }
+        cachedStartElement = null;
+    }
+
+    shared
+    void docType(String docType) {
+        // FIXME validate/escape docType
+        // just ignore if we are in an element
+        if (elementStack.top is Null && cachedStartElement is Null) {
+            print(docType);
+            print("\n");
+        }
+    }
+
+    shared
+    void startElement(
+            String elementName,
+            {<String->Object>*} attributes = {}) {
+        // TODO disallow elements in raw and escapableRaw elements?
+        // fail fast at the cost of efficiency
+        assert(name.isValid(elementName));
+        flushText();
+        flushStartElement();
+        cachedStartElement = [elementName, attributes];
+    }
+
+    shared
+    void endElement() {
+        if (cachedStartElement exists) {
+            assert(bufferedText.empty);
+            flushStartElement(true);
+        }
+        else {
+            flushText();
+            assert(exists elementName = elementStack.pop());
+            print("</" + escape(elementName, name) + ">");
+        }
+    }
+
+    shared
+    void text(String text) {
+        flushStartElement();
+        bufferedText.append(text);
+    }
+
+    shared
+    void flush() {
+        flushText();
+        flushStartElement(true);
+    }
+}

--- a/source/ceylon/html/serializer/NodeSerializer.ceylon
+++ b/source/ceylon/html/serializer/NodeSerializer.ceylon
@@ -18,14 +18,29 @@ shared class NodeSerializer(
 
     shared void serialize(Node root) => visit(root);
 
-    void visitAny(Node|{Node*}|Snippet<Node> child) {
-        if (is Node child) {
-            visit(child);
-        } else if (is {Node*} child) {
-            visitNodes(child);
-        } else if (exists content = child.content) {
-            visitAny(content);
+    void visitAny(Node|String|{Node|String*}|Snippet<Node> child) {
+        switch (child)
+        case (is String) {
+            visitString(child);
         }
+        case (is Node) {
+            visit(child);
+        }
+        else {
+            switch (child)
+            case (is Snippet<Node>) {
+                if (exists content = child.content) {
+                    visitAny(content);
+                }
+            }
+            else { // is {Node|String*} 
+                visitNodes(child);
+            }
+        }
+    }
+
+    void visitString(String string) {
+        htmlSerializer.text(string);
     }
 
     void visit(Node node) {
@@ -68,9 +83,15 @@ shared class NodeSerializer(
     void closeTag(Node node)
         =>  htmlSerializer.endElement();
 
-    void visitNodes({Node*} nodes) {
+    void visitNodes({Node|String*} nodes) {
         for (node in nodes) {
-            visit(node);
+            switch (node)
+            case (is String) {
+                visitString(node);
+            }
+            case (is Node) {
+                visit(node);
+            }
         }
     }
 }

--- a/source/ceylon/html/serializer/NodeSerializer.ceylon
+++ b/source/ceylon/html/serializer/NodeSerializer.ceylon
@@ -3,10 +3,8 @@ import ceylon.html {
     Html,
     Element,
     TextNode,
-    blockTag,
     ParentNode,
-    Snippet,
-    emptyTag
+    Snippet
 }
 
 shared class NodeSerializer(
@@ -15,10 +13,8 @@ shared class NodeSerializer(
     "Serialization options"
     SerializerConfig config = SerializerConfig()
 ) {
-
-    variable value indentLevel = 0;
-
-    value prettyPrint = config.prettyPrint;
+    value htmlSerializer = HtmlSerializer(
+            print, config.prettyPrint, config.escapeNonAscii);
 
     shared void serialize(Node root) => visit(root);
 
@@ -31,92 +27,52 @@ shared class NodeSerializer(
             visitAny(content);
         }
     }
-    
+
     void visit(Node node) {
         if (is Html node) {
-            startHtml(node);
+            htmlSerializer.docType(node.doctype.string);
         }
-        indent();
         openTag(node);
-        if (is Element node) {
-            visitElement(node);
-        }
-        endOpenTag(node);
-        indentLevel++;
-        if (is TextNode node, !node.text.trimmed.empty) {
-            linefeed();
-            indent();
-            print(node.text);
+        if (is TextNode node) {
+            htmlSerializer.text(node.text);
         }
         if (is ParentNode<Node> node) {
             for (child in node.children) {
                 if (exists child) {
-                    linefeed();
                     visitAny(child);
                 }
             }
         }
-        indentLevel--;
-        if (node.tag.type == blockTag) {
-            linefeed();
-            indent();
-            closeTag(node);
-        }
+        closeTag(node);
     }
 
-    void startHtml(Html html) {
-        print(html.doctype.string);
-        linefeed(true);
-        linefeed();
+    void openTag(Node node) {
+        // TODO previous code
+        //      1) trimmed attribute value
+        //      2) omitted attribute if trimmed value was empty
+        // Not sure that was correct; these are not invalid cases
+        value attributes =
+                if (is Element node)
+                then node.attributes
+                else {};
+
+        // for now, duplicate bug that drops attributes with empty value
+        // only call "string" once:
+        value nonEmptyAttributes = attributes.map((attribute)
+                => attribute.key->attribute.item.string).filter((attribute)
+                => !attribute.item.empty);
+
+        htmlSerializer.startElement(node.tag.name, nonEmptyAttributes);
     }
 
-    void visitElement(Element node) {
-        printAttributes(node);
-    }
-
-    void openTag(Node node) => print("<``node.tag.name``");
-
-    void endOpenTag(Node node) {
-        if (node.tag.type == emptyTag) {
-            print(" /");
-        }
-        print(">");
-    }
-
-    void closeTag(Node node) => print("</``node.tag.name``>");
-
-    void printAttributes(Element node) {
-        for (attrName->attrValue in node.attributes) {
-            value val = attrValue.string.trimmed;
-            if (!val.empty) {
-                print(" ``attrName``=\"``attrValue``\"");
-            }
-        }
-    }
+    void closeTag(Node node)
+        =>  htmlSerializer.endElement();
 
     void visitNodes({Node*} nodes) {
         for (node in nodes) {
             visit(node);
         }
     }
-
-    void linefeed(Boolean force = false) {
-        if (prettyPrint || force) {
-            print(operatingSystem.newline);
-        }
-    }
-
-    void indent() {
-        if (prettyPrint) {
-            print(indentString);
-        }
-    }
-
-    String indentString {
-        value spaces = indentLevel * 4;
-        return spaces > 0 then " ".repeat(spaces) else "";
-    }
-
 }
 
 "A [[NodeSerializer]] implementation that prints content on console."

--- a/source/ceylon/html/serializer/NodeSerializer.ceylon
+++ b/source/ceylon/html/serializer/NodeSerializer.ceylon
@@ -45,7 +45,7 @@ shared class NodeSerializer(
 
     void visit(Node node) {
         if (is Html node) {
-            htmlSerializer.docType(node.doctype.string);
+            htmlSerializer.doctype(node.doctype.string);
         }
         openTag(node);
         if (is TextNode node) {
@@ -62,20 +62,16 @@ shared class NodeSerializer(
     }
 
     void openTag(Node node) {
-        // TODO previous code
-        //      1) trimmed attribute value
-        //      2) omitted attribute if trimmed value was empty
-        // Not sure that was correct; these are not invalid cases
         value attributes =
                 if (is Element node)
                 then node.attributes
                 else {};
 
-        // for now, duplicate bug that drops attributes with empty value
-        // only call "string" once:
-        value nonEmptyAttributes = attributes.map((attribute)
-                => attribute.key->attribute.item.string).filter((attribute)
-                => !attribute.item.empty);
+        // for now, duplicate bug that drops attributes
+        // with empty value
+        value nonEmptyAttributes = attributes
+            .map((attribute) => attribute.key->attribute.item.string)
+            .filter((attribute) => !attribute.item.empty);
 
         htmlSerializer.startElement(node.tag.name, nonEmptyAttributes);
     }

--- a/source/ceylon/html/serializer/NodeSerializer.ceylon
+++ b/source/ceylon/html/serializer/NodeSerializer.ceylon
@@ -18,18 +18,9 @@ shared class NodeSerializer(
 
     variable value indentLevel = 0;
 
-    variable value sizeCount = 0;
-
     value prettyPrint = config.prettyPrint;
 
     shared void serialize(Node root) => visit(root);
-
-    shared Integer contentLength => sizeCount;
-
-    void doPrint(String string) {
-        sizeCount += string.size; // TODO accurate byte size?
-        print(string);
-    }
 
     void visitAny(Node|{Node*}|Snippet<Node> child) {
         if (is Node child) {
@@ -55,7 +46,7 @@ shared class NodeSerializer(
         if (is TextNode node, !node.text.trimmed.empty) {
             linefeed();
             indent();
-            doPrint(node.text);
+            print(node.text);
         }
         if (is ParentNode<Node> node) {
             for (child in node.children) {
@@ -74,7 +65,7 @@ shared class NodeSerializer(
     }
 
     void startHtml(Html html) {
-        doPrint(html.doctype.string);
+        print(html.doctype.string);
         linefeed(true);
         linefeed();
     }
@@ -83,22 +74,22 @@ shared class NodeSerializer(
         printAttributes(node);
     }
 
-    void openTag(Node node) => doPrint("<``node.tag.name``");
+    void openTag(Node node) => print("<``node.tag.name``");
 
     void endOpenTag(Node node) {
         if (node.tag.type == emptyTag) {
-            doPrint(" /");
+            print(" /");
         }
-        doPrint(">");
+        print(">");
     }
 
-    void closeTag(Node node) => doPrint("</``node.tag.name``>");
+    void closeTag(Node node) => print("</``node.tag.name``>");
 
     void printAttributes(Element node) {
         for (attrName->attrValue in node.attributes) {
             value val = attrValue.string.trimmed;
             if (!val.empty) {
-                doPrint(" ``attrName``=\"``attrValue``\"");
+                print(" ``attrName``=\"``attrValue``\"");
             }
         }
     }
@@ -111,13 +102,13 @@ shared class NodeSerializer(
 
     void linefeed(Boolean force = false) {
         if (prettyPrint || force) {
-            doPrint(operatingSystem.newline);
+            print(operatingSystem.newline);
         }
     }
 
     void indent() {
         if (prettyPrint) {
-            doPrint(indentString);
+            print(indentString);
         }
     }
 

--- a/source/ceylon/html/serializer/SerializerConfig.ceylon
+++ b/source/ceylon/html/serializer/SerializerConfig.ceylon
@@ -2,7 +2,10 @@ import ceylon.html { Doctype, html5 }
 
 "Defines configuration options that changes serialization behavior."
 see(`class NodeSerializer`)
-shared class SerializerConfig(prettyPrint = true, defaultDoctype = html5) {
+shared class SerializerConfig(
+            prettyPrint = true,
+            defaultDoctype = html5,
+            escapeNonAscii = false) {
 
     "Should the result be minified or formatted? Defaults to `true`"
     shared Boolean prettyPrint;
@@ -12,4 +15,7 @@ shared class SerializerConfig(prettyPrint = true, defaultDoctype = html5) {
      Defaults to [[html5]]"
     shared Doctype defaultDoctype;
 
+    "Should non-ASCII characters be escaped? Defaults to `false`. If `false`,
+     the document's characterset should be UTF-8."
+    shared Boolean escapeNonAscii;
 }

--- a/source/ceylon/html/serializer/constants.ceylon
+++ b/source/ceylon/html/serializer/constants.ceylon
@@ -1,0 +1,51 @@
+import ceylon.collection {
+    unmodifiableSet,
+    HashSet
+}
+
+Range<Character> asciiCharacterRange = ' '..'~';
+
+// can't use Range<Character> since these are
+// not all valid code points (e.g. #37F)
+// http://www.w3.org/TR/REC-xml/#NT-NameChar
+[Range<Integer>+] xmlNameStartCharRanges = [
+        ':'.integer..':'.integer,
+        '_'.integer..'_'.integer,
+        'A'.integer..'Z'.integer,
+        'a'.integer..'z'.integer,
+        #C0..#D6,
+        #D8..#F6,
+        #F8..#2FF,
+        #370..#37D,
+        #37F..#1FFF,
+        #200C..#200D,
+        #2070..#218F,
+        #2C00..#2FEF,
+        #3001..#D7FF,
+        #F900..#FDCF,
+        #FDF0..#FFFD,
+        #10000..#EFFFF];
+
+// http://www.w3.org/TR/REC-xml/#NT-NameChar
+[Range<Integer>+] xmlNameCharRanges = [
+        '-'.integer..'-'.integer,
+        '.'.integer..'.'.integer,
+        '0'.integer..'9'.integer,
+        #B7..#B7,
+        #300..#36F,
+        #203F..#2040,
+        *xmlNameStartCharRanges];
+
+// http://www.w3.org/TR/html5/syntax.html#elements-0
+Set<String> voidElements = unmodifiableSet(HashSet {
+        "area", "base", "br", "col", "embed", "hr",
+        "img", "input", "keygen", "link", "meta",
+        "param", "source", "track", "wbr"});
+
+// http://www.w3.org/TR/html5/syntax.html#elements-0
+Set<String> rawTextElements = unmodifiableSet(HashSet {
+        "script", "style"});
+
+// http://www.w3.org/TR/html5/syntax.html#elements-0
+Set<String> escapableRawTextElements = unmodifiableSet(HashSet {
+        "textarea", "title"});

--- a/source/ceylon/html/serializer/constants.ceylon
+++ b/source/ceylon/html/serializer/constants.ceylon
@@ -49,3 +49,22 @@ Set<String> rawTextElements = unmodifiableSet(HashSet {
 // http://www.w3.org/TR/html5/syntax.html#elements-0
 Set<String> escapableRawTextElements = unmodifiableSet(HashSet {
         "textarea", "title"});
+
+Set<String> blockElements = unmodifiableSet(HashSet {
+        "address", "article", "aside", "audio", "blockquote", "canvas",
+        "dd", "div", "dl", "fieldset", "figcaption", "figure", "footer",
+        "form", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup",
+        "hr", "main", "nav", "noscript", "ol", "output", "p", "pre",
+        "section", "table", "tfoot", "ul", "video"});
+
+Set<String> metadataElements = unmodifiableSet(HashSet {
+        "base", "command", "link", "meta", "noscript",
+        "script", "style", "title"});
+
+Set<String> indentElements = (function() {
+    value set = HashSet<String>();
+    set.addAll(blockElements);
+    set.addAll(metadataElements);
+    set.addAll({"html", "head", "body"});
+    return unmodifiableSet(set);
+})();

--- a/source/ceylon/html/serializer/htmlEscape.ceylon
+++ b/source/ceylon/html/serializer/htmlEscape.ceylon
@@ -1,0 +1,76 @@
+// TODO cdata http://www.w3.org/TR/html5/syntax.html#cdata-sections
+// should probably have a cdata and comment node types
+String htmlEscape(String raw, EscapableType type, Boolean escapeNonAscii, String? forTag=null) {
+    if (is \Iname type) {
+        assert(name.isValid(raw));
+        if (escapeNonAscii && raw.any((c)
+                => !asciiCharacterRange.contains(c))) {
+            throw Exception(
+                "Unescapable non-ascii character found in tag name '``raw``'.");
+        }
+        // return; names don't have CRLF
+        return raw;
+    } else if (is \IrawText type) {
+        assert (exists forTag);
+        value lowerRaw = raw.lowercased;
+        value lowerTag = forTag.lowercased;
+        // make sure doesn't contain something like "</script"
+        if (lowerRaw.contains("</" + lowerTag)) {
+            throw Exception(
+                "Unescapable string '</``forTag``' found in rawText content.");
+        }
+        // disallow comments (if necessary, a comment node type should be created)
+        if (raw.contains("<!--")) {
+            throw Exception(
+                "Unescapable string '<!--' found in rawText content.");
+        }
+        // make sure only ascii chars are present if escapeNonAscii is true
+        if (escapeNonAscii && raw.any((c)
+                => !asciiCharacterRange.contains(c) && c != '\r' && c != '\n' && c != '\t')) {
+            throw Exception(
+                "Unescapable non-ascii character found in rawText content.");
+        }
+        // continue with CRLF normalization
+    }
+
+    // CRLF normalization not necessary per
+    // http://www.w3.org/TR/html5/syntax.html#newlines
+    // but we'll do it anyway
+    variable value lastWasCR = false;
+
+    value sb = StringBuilder();
+
+    value entities = type.entities;
+
+    for (c in raw) {
+        if (lastWasCR) {
+            if (c != '\n') {
+                // output CR not followed by LF as LF
+                sb.appendCharacter('\n');
+            }
+            lastWasCR = false;
+        }
+
+        if (c == '\r') {
+            lastWasCR = true;
+        }
+        else if (exists replacement = entities[c]) {
+            sb.append(replacement);
+        }
+        else if (escapeNonAscii
+                    && !asciiCharacterRange.containsElement(c)
+                    && !c == '\t'
+                    && !c == '\n') {
+            sb.append("&#");
+            sb.append(c.integer.string);
+            sb.appendCharacter(';');
+        }
+        else {
+            sb.appendCharacter(c);
+        }
+    }
+    if (lastWasCR) {
+        sb.appendCharacter('\n');
+    }
+    return sb.string;
+}

--- a/source/ceylon/html/serializer/htmlEscape.ceylon
+++ b/source/ceylon/html/serializer/htmlEscape.ceylon
@@ -1,6 +1,7 @@
-// TODO cdata http://www.w3.org/TR/html5/syntax.html#cdata-sections
-// should probably have a cdata and comment node types
-String htmlEscape(String raw, EscapableType type, Boolean escapeNonAscii, String? forTag=null) {
+String htmlEscape(
+        String raw, EscapableType type,
+        Boolean escapeNonAscii, String? forTag=null) {
+
     if (is \Iname type) {
         assert(name.isValid(raw));
         if (escapeNonAscii && raw.any((c)
@@ -26,11 +27,12 @@ String htmlEscape(String raw, EscapableType type, Boolean escapeNonAscii, String
         }
         // make sure only ascii chars are present if escapeNonAscii is true
         if (escapeNonAscii && raw.any((c)
-                => !asciiCharacterRange.contains(c) && c != '\r' && c != '\n' && c != '\t')) {
+                => !asciiCharacterRange.contains(c)
+                        && c != '\r' && c != '\n' && c != '\t')) {
             throw Exception(
                 "Unescapable non-ascii character found in rawText content.");
         }
-        // continue with CRLF normalization
+        // don't return yet, continue with CRLF normalization
     }
 
     // CRLF normalization not necessary per

--- a/test-source/test/ceylon/html/serialization.ceylon
+++ b/test-source/test/ceylon/html/serialization.ceylon
@@ -16,7 +16,10 @@ import ceylon.html {
     InlineElement,
     I,
     B,
-    Pre
+    Pre,
+    Cite,
+    Strong,
+    P
 }
 import ceylon.html.serializer {
     NodeSerializer,
@@ -323,6 +326,21 @@ void testAscii() {
     testUtf8(t5, "<textarea>汉字</textarea>");
 }
 
+shared test
+void testMixedContent() {
+    function test(Node actual, String expected)
+        =>  runTest(actual, expected, true, false);
+
+    // bug #344
+    test(Div { "Some text", Cite("world"), "!" },
+        "<div>Some text<cite>world</cite>!</div>\n");
+
+    // bug #346
+    test(P { "This is a paragraph containing ",
+            Strong("boldened"), "text!" },
+        "<p>This is a paragraph containing <strong>boldened</strong>text!</p>\n");
+}
+
 void runTest(Node actual, String expected, Boolean prettyPrint, Boolean escapeNonAscii) {
     assertEquals(serializeToString(actual, prettyPrint, escapeNonAscii), expected);
 }
@@ -352,5 +370,5 @@ class Custom(
     Tag tag = Tag(tagName, blockTag);
 
     shared actual
-    {<BlockOrInline|{BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
+    {<String|BlockOrInline|{String|BlockOrInline*}|Snippet<BlockOrInline>|Null>*} children;
 }

--- a/test-source/test/ceylon/html/serialization.ceylon
+++ b/test-source/test/ceylon/html/serialization.ceylon
@@ -4,7 +4,11 @@ import ceylon.html {
     Head,
     html5,
     Body,
-    Div
+    Div,
+    Element,
+    Tag,
+    blockTag,
+    TextNode
 }
 import ceylon.html.serializer {
     NodeSerializer,
@@ -12,13 +16,15 @@ import ceylon.html.serializer {
 }
 import ceylon.test {
     assertEquals,
-    test
+    test,
+    assertThatException,
+    ignore
 }
 
 object testData {
     shared
     Html emptyPage = Html();
-    
+
     shared
     Html pageWithContent = Html {
         html5;
@@ -27,7 +33,7 @@ object testData {
     };
 }
 
-shared test
+shared test ignore("pretty print not yet supported")
 void testPrettyPrintSimple() {
     runTest {
         prettyPrint = true;
@@ -94,14 +100,172 @@ void testSimple() {
     };
 }
 
+shared test
+void testAttributeName() {
+    function test(Node actual, String expected)
+        =>  runTest(actual, expected, false, false);
+
+    function testThrows(Node actual)
+        =>  runTestException(actual, false, false);
+
+    test(Div { nonstandardAttributes = [ "att" -> "0" ]; },
+            "<div att=\"0\"></div>");
+
+    test(Div { nonstandardAttributes = [ "汉字" -> "0" ]; },
+            "<div 汉字=\"0\"></div>");
+
+    // illegal name characters
+    testThrows(Div { nonstandardAttributes = [ "att<" -> "0" ]; });
+    testThrows(Div { nonstandardAttributes = [ "att>" -> "0" ]; });
+    testThrows(Div { nonstandardAttributes = [ "att\'" -> "0" ]; });
+    testThrows(Div { nonstandardAttributes = [ ".att" -> "0" ]; });
+    test(Div { nonstandardAttributes = [ "a.tt" -> "0" ]; },
+        "<div a.tt=\"0\"></div>");
+}
+
+shared test
+void testText() {
+    function test(Node actual, String expected)
+        =>  runTest(actual, expected, false, false);
+
+    test(Div("content"), "<div>content</div>");
+    test(Div("content汉字"), "<div>content汉字</div>");
+    test(Div("<"), "<div>&lt;</div>");
+    test(Div("&"), "<div>&amp;</div>");
+    test(Div(">'\" "), "<div>>'\" </div>");
+    test(Div("<,>,&,',\", "), "<div>&lt;,>,&amp;,',\", </div>");
+}
+
+shared test
+void testAttributeValue() {
+    function test(Node actual, String expected)
+        =>  runTest(actual, expected, false, false);
+
+    test(Div { nonstandardAttributes = ["att"->"content"]; }, "<div att=\"content\"></div>");
+    test(Div { nonstandardAttributes = ["att"->"汉字"]; }, "<div att=\"汉字\"></div>");
+    test(Div { nonstandardAttributes = ["att"->"<"]; }, "<div att=\"<\"></div>");
+    test(Div { nonstandardAttributes = ["att"->">"]; }, "<div att=\">\"></div>");
+    test(Div { nonstandardAttributes = ["att"->"&"]; }, "<div att=\"&amp;\"></div>");
+    test(Div { nonstandardAttributes = ["att"->"'"]; }, "<div att=\"&#39;\"></div>");
+    test(Div { nonstandardAttributes = ["att"->"\""]; }, "<div att=\"&quot;\"></div>");
+    test(Div { nonstandardAttributes = ["att"->"multi\nline"]; }, "<div att=\"multi\nline\"></div>");
+    test(Div { nonstandardAttributes = ["att"->"trailing sp "]; }, "<div att=\"trailing sp \"></div>");
+    test(Div { nonstandardAttributes = ["att"->" leading sp"]; }, "<div att=\" leading sp\"></div>");
+}
+
+shared test
+void testRawText() {
+    function test(Node actual, String expected)
+        =>  runTest(actual, expected, false, false);
+
+    function testThrows(Node actual)
+        =>  runTestException(actual, false, false);
+
+    // don't escape
+    test(Custom("script", "汉字"), "<script>汉字</script>");
+    test(Custom("script", "<>&'\""), "<script><>&'\"</script>");
+
+    // don't allow "</tagName" or "<!--"
+    testThrows(Custom("script", "xx </script xx"));
+    testThrows(Custom("script", "xx <!-- xx"));
+}
+
+shared test
+void testEscapableRawText() {
+    function test(Node actual, String expected)
+        =>  runTest(actual, expected, false, false);
+
+    // only need to escape < and &
+    test(Custom("textarea", "汉字"), "<textarea>汉字</textarea>");
+    test(Custom("textarea", ">'\""), "<textarea>>'\"</textarea>");
+    test(Custom("textarea", "<&"), "<textarea>&lt;&amp;</textarea>");
+
+    // allow, but escape "</tagName" or "<!--"
+    test(Custom("textarea", "xx </textarea xx"), "<textarea>xx &lt;/textarea xx</textarea>");
+    test(Custom("textarea", "xx <!-- xx"), "<textarea>xx &lt;!-- xx</textarea>");
+}
+
+shared test
+void testNewlines() {
+    function test(Node actual, String expected)
+        =>  runTest(actual, expected, false, false);
+
+    value input = "line1\nline2\rline3\r\rline5\r\nline6\r\r\nline9\n\rline12";
+    value expected = "line1\nline2\nline3\n\nline5\nline6\n\nline9\n\nline12";
+
+    // attribute value
+    test(Div { nonstandardAttributes = ["att"->input]; }, "<div att=\"``expected``\"></div>");
+
+    // div text (text)
+    test(Div(input), "<div>``expected``</div>");
+
+    // script text (rawText)
+    test(Custom("script", input), "<script>``expected``</script>");
+
+    // textarea text (escapableRawText)
+    test(Custom("textarea", input), "<textarea>``expected``</textarea>");
+}
+
+shared test
+void testAscii() {
+    function testAsciiThrows(Node actual)
+        =>  runTestException(actual, false, true);
+
+    function testAscii(Node actual, String expected)
+        =>  runTest(actual, expected, false, true);
+
+    function testUtf8(Node actual, String expected)
+        =>  runTest(actual, expected, false, false);
+
+    // non-ascii attribute name
+    value t1 = Div { nonstandardAttributes = [ "汉字" -> "10" ]; };
+    testAsciiThrows(t1);
+    testUtf8(t1, "<div 汉字=\"10\"></div>");
+
+    // non-ascii attribute value
+    value t2 = Div { nonstandardAttributes = [ "att" -> "汉字" ]; };
+    testAscii(t2, "<div att=\"&#27721;&#23383;\"></div>");
+    testUtf8(t2, "<div att=\"汉字\"></div>");
+
+    // non-ascii text (text)
+    value t3 = Div("汉字");
+    testAscii(t3, "<div>&#27721;&#23383;</div>");
+    testUtf8(t3, "<div>汉字</div>");
+
+    // non-ascii rawText (can't escape, don't allow)
+    value t4 = Custom("script", "汉字");
+    testAsciiThrows(t4);
+    testUtf8(t4, "<script>汉字</script>");
+
+    // non-ascii escapableRawText
+    value t5 = Custom("textarea", "汉字");
+    testAscii(t5, "<textarea>&#27721;&#23383;</textarea>");
+    testUtf8(t5, "<textarea>汉字</textarea>");
+}
+
 void runTest(Node actual, String expected, Boolean prettyPrint, Boolean escapeNonAscii) {
     assertEquals(serializeToString(actual, prettyPrint, escapeNonAscii), expected);
 }
 
+void runTestException(Node actual, Boolean prettyPrint, Boolean escapeNonAscii) {
+    assertThatException(() => serializeToString(actual, prettyPrint, escapeNonAscii));
+}
+
 String serializeToString(Node node, Boolean prettyPrint, Boolean escapeNonAscii) {
     value builder = StringBuilder();
-    value serializer = NodeSerializer(builder.append, 
+    value serializer = NodeSerializer(builder.append,
             SerializerConfig(prettyPrint, html5, escapeNonAscii));
     serializer.serialize(node);
     return builder.string;
+}
+
+class Custom(
+        String tagName,
+        shared actual String text = "",
+        shared actual [<String->Object>*] attributes = [],
+        String? id = null) extends Element(id)
+        satisfies TextNode {
+
+    shared actual
+    Tag tag = Tag(tagName, blockTag);
 }

--- a/test-source/test/ceylon/html/serialization.ceylon
+++ b/test-source/test/ceylon/html/serialization.ceylon
@@ -15,85 +15,93 @@ import ceylon.test {
     test
 }
 
-
 object testData {
+    shared
+    Html emptyPage = Html();
     
-    shared Html emptyPage = Html();
-    
-    shared Html pageWithContent = Html {
+    shared
+    Html pageWithContent = Html {
         html5;
-        Head {
-            title = "page title";
-        };
-        Body {
-            Div("page content")
-        };
+        Head { title = "page title"; };
+        Body { Div("page content") };
+    };
+}
+
+shared test
+void testPrettyPrintSimple() {
+    runTest {
+        prettyPrint = true;
+        escapeNonAscii = false;
+        actual = testData.emptyPage;
+        expected =
+            """
+               <!DOCTYPE html>
+
+               <html>
+                   <head>
+                       <title>
+                       </title>
+                   </head>
+                   <body>
+                   </body>
+               </html>
+               """;
     };
 
-}
+    runTest {
+        prettyPrint = true;
+        escapeNonAscii = false;
+        actual = testData.pageWithContent;
+        expected =
+            """
+               <!DOCTYPE html>
 
-
-shared test void testPrettyPrintSerialization() {
-    value expectedOutput = {
-        testData.emptyPage ->
-                """
-                   <!DOCTYPE html>
-                   
-                   <html>
-                       <head>
-                           <title>
-                           </title>
-                       </head>
-                       <body>
-                       </body>
-                   </html>
-                   """,
-        testData.pageWithContent ->
-                """
-                   <!DOCTYPE html>
-                   
-                   <html>
-                       <head>
-                           <title>
-                               page title
-                           </title>
-                       </head>
-                       <body>
-                           <div>
-                               page content
-                           </div>
-                       </body>
-                   </html>
-                   """
+               <html>
+                   <head>
+                       <title>
+                           page title
+                       </title>
+                   </head>
+                   <body>
+                       <div>
+                           page content
+                       </div>
+                   </body>
+               </html>
+               """;
     };
-    doTestExpectedOutput(expectedOutput, true);
 }
 
-shared test void testMinifiedSerialization() {
-    value expectedOutput = {
-        testData.emptyPage ->
-                "<!DOCTYPE html>
-                 <html><head><title></title></head><body></body></html>",
-        testData.pageWithContent ->
-                "<!DOCTYPE html>
-                 <html><head><title>page title</title></head>" +
-                "<body><div>page content</div></body></html>"
+shared test
+void testSimple() {
+    runTest {
+        prettyPrint = true;
+        escapeNonAscii = false;
+        actual = testData.emptyPage;
+        expected =
+            "<!DOCTYPE html>
+             <html><head><title></title></head><body></body></html>";
     };
-    doTestExpectedOutput(expectedOutput);
+
+    runTest {
+        prettyPrint = true;
+        escapeNonAscii = false;
+        actual = testData.pageWithContent;
+        expected =
+            "<!DOCTYPE html>
+             <html><head><title>page title</title></head>" +
+            "<body><div>page content</div></body></html>";
+    };
 }
 
-void doTestExpectedOutput(
-        {<Node->String>+} expectedResults,
-        Boolean prettyPrint = false) {
-    for (node->string in expectedResults) {
-        assertEquals(string.trimmed.replace("\n", operatingSystem.newline), serializeToString(node, prettyPrint));
-    }
+void runTest(Node actual, String expected, Boolean prettyPrint, Boolean escapeNonAscii) {
+    assertEquals(serializeToString(actual, prettyPrint, escapeNonAscii), expected);
 }
 
-String serializeToString(Node node, Boolean prettyPrint) {
+String serializeToString(Node node, Boolean prettyPrint, Boolean escapeNonAscii) {
     value builder = StringBuilder();
     value serializer = NodeSerializer(builder.append, 
-            SerializerConfig(prettyPrint));
+            SerializerConfig(prettyPrint, html5, escapeNonAscii));
     serializer.serialize(node);
     return builder.string;
 }

--- a/test-source/test/ceylon/html/serialization.ceylon
+++ b/test-source/test/ceylon/html/serialization.ceylon
@@ -341,6 +341,28 @@ void testMixedContent() {
         "<p>This is a paragraph containing <strong>boldened</strong>text!</p>\n");
 }
 
+shared test
+void testEscapingBug403Utf8() {
+    runTest {
+        prettyPrint = false;
+        escapeNonAscii = false;
+        actual = Div { id="»"; "»" };
+        expected =
+           """<div id="»">»</div>""";
+    };
+}
+
+shared test
+void testEscapingBug403Ascii() {
+    runTest {
+        prettyPrint = false;
+        escapeNonAscii = true;
+        actual = Div { id="»"; "»" };
+        expected =
+           """<div id="&#187;">&#187;</div>""";
+    };
+}
+
 void runTest(Node actual, String expected, Boolean prettyPrint, Boolean escapeNonAscii) {
     assertEquals(serializeToString(actual, prettyPrint, escapeNonAscii), expected);
 }


### PR DESCRIPTION
* Removes the `contentLength` property, see first commit
* Fixes:
    * https://github.com/ceylon/ceylon-sdk/issues/344
    * https://github.com/ceylon/ceylon-sdk/issues/345
    * https://github.com/ceylon/ceylon-sdk/issues/346
    * https://github.com/ceylon/ceylon-sdk/issues/355
    * https://github.com/ceylon/ceylon-sdk/issues/356

The new class `HtmlSerializer` separates html serialization concerns from the rest of the code, and in theory could be used independently (but is not shared). It keeps its own static metadata about some html tags, which could instead be taken instead from the tag instances, but perfect is the enemy of done, and the separation of concerns may actually be useful depending on how the module evolves re heavy-handedness.

There is a new `escapeNonAscii` parameter for `SerializerConfig`, that if `true`, ensures the output contains only ascii characters (or throws if impossible, for instance if non-ascii characters appear inside a `script` tag.) Feel free to suggest a better name for this.

The off-topic note in #356 about empty attributes being eaten remains (this PR preserves the bug).

I added a number of tests and also tried this out with a simple webapp. I'll probably give this another once-over a bit later tonight or tomorrow.