### PR TITLE
Refactor Java array updates and support empty Java arrays

### DIFF
--- a/source/ceylon/dbc/Sql.ceylon
+++ b/source/ceylon/dbc/Sql.ceylon
@@ -40,6 +40,7 @@ import java.lang {
     JBoolean=Boolean,
     JInteger=Integer,
     JLong=Long,
+    JFloat=Float,
     JString=String,
     ObjectArray,
     ByteArray
@@ -239,73 +240,76 @@ shared class Sql(newConnection) {
 
         stmt.setBinaryStream(position, ByteArrayInputStream(byteArray), byteArray.size); 
     }
-    
+
     String sqlArrayType(ObjectArray<Object> argument) {
-        if (argument.size > 0) {
-            value first = argument.get(0);
-            
-            /*
-             TODO:  Due to https://github.com/ceylon/ceylon-compiler/issues/1753, we need to check the type of 
-                    first element of the array to determine the type of the database array.
-                    There is also the question of non-standard behaviour for at least on database, PostgreSQL,
-                    which will only accept lowercase versions of the types below.  (ex varchar, but not VARCHAR).
-                    As well, JDK 8 has java.sql.JDBCType that contains these String values, but JDK 7 does not,
-                    which is why the values below are hard-coded.
-                    
-             */
-            switch (first)
-            case (is String) {
-                return "varchar";
-            }
-            case (is Integer) {
-                return "integer";
-            }
-            case (is Boolean) {
-                return "boolean";
-            }
-            case (is Decimal) {
-                return "decimal";
-            }
-            case (is Float) {
-                return "float";
-            }
-            case (is JDate) {
-                if (is SqlTimestamp first) {
-                    return "timestamp";
-                } 
-                else if (is SqlTime first) {
-                    return "time";
-                }
-                else if (is SqlDate first) {
-                    return "date";
-                }
-                else {
-                    return "timestamp";
-                }
-            }
-            case (is GregorianDateTime) {
-                return "timestamp";
-            }
-            case (is GregorianDate) {
-                return "date";
-            }
-            case (is TimeOfDay) {
-                return "time";
-            }
-            // This is a special case not part of JDBCTypes but is supported by H2 and PostgreSQL.
-            case (is UUID) {
-                return "uuid";
-            }
-            else {
-                // TODO:  All other possible array types
-                throw Exception("Unsupported array data type");
-            }
+        if (is ObjectArray<String> argument) {
+            return "varchar";
         }
 
-        // TODO: This is a bug.  If it's the user's intent to provide an empty array, it is impossible to know
-        // which type that array is for.  Fixing this is blocked by: 
-        // https://github.com/ceylon/ceylon-compiler/issues/1753
-        throw Exception("Cannot infer the type of an empty array so it will be impossible to insert or update it");
+        if (is ObjectArray<JString> argument) {
+            return "varchar";
+        }
+
+        if (is ObjectArray<Integer> argument) {
+            return "integer";
+        }
+
+        if (is ObjectArray<JInteger> argument) {
+            return "integer";
+        }
+
+        if (is ObjectArray<JBoolean> argument) {
+            return "boolean";
+        }
+
+        if (is ObjectArray<Boolean> argument) {
+            return "boolean";
+        }
+
+        if (is ObjectArray<JFloat> argument) {
+            return "float";
+        }
+
+        if (is ObjectArray<Float> argument) {
+            return "float";
+        }
+
+        if (is ObjectArray<SqlTimestamp> argument) {
+            return "timestamp";
+        }
+
+        if (is ObjectArray<SqlTime> argument) {
+            return "time";
+        }
+
+        if (is ObjectArray<SqlDate> argument) {
+            return "date";
+        }
+
+        if (is ObjectArray<JDate> argument) {
+            return "timestamp";
+        }
+
+        if (is ObjectArray<GregorianDateTime> argument) {
+            return "timestamp";
+        }
+
+        if (is ObjectArray<GregorianDate> argument) {
+            return "date";
+        }
+
+        if (is ObjectArray<TimeOfDay> argument) {
+            return "time";
+        }
+
+        // This is a special case not part of JDBCTypes but is supported by H2 and PostgreSQL.
+        if (is ObjectArray<UUID> argument) {
+            return "uuid";
+        }
+
+        // TODO:  All other possible array types
+
+        throw Exception("Unsupported array data type");
     }
     
     CallableStatement prepareCall(ConnectionStatus conn, String sql, {Object*} arguments) {


### PR DESCRIPTION
Refactor Java array updating by doing "is" typechecks on the array instead of checking the type of the first element.  Introduce support for empty arrays of a certain type (ex ObjectArray<Date>).

This was tested against a PostgreSQL database and table with multiple array type columns.