### PR TITLE
Add CeylonStringMap and CeylonStringMutableMap

### DIFF
--- a/source/ceylon/interop/java/CeylonStringMap.ceylon
+++ b/source/ceylon/interop/java/CeylonStringMap.ceylon
@@ -1,0 +1,54 @@
+import java.lang {
+    JString=String
+}
+
+"A [[Map]] with keys of type `ceylon.language::String` that
+ wraps a `Map` with keys of type `java.lang.String`.
+
+ This class can be used to wrap a `java.util::Map` if the
+ Java map is first wrapped with [[CeylonMap]]:
+
+        CeylonStringMap(CeylonMap(javaMap))
+"
+shared
+class CeylonStringMap<out Item>(Map<JString, Item> map)
+        satisfies Map<String, Item> {
+
+    shared actual default
+    CeylonStringMap<Item> clone()
+        =>  CeylonStringMap(map.clone());
+
+    shared actual
+    Boolean defines(Object key)
+        // don't forward non-Strings; otherwise, what to do
+        // when the arg is java.lang.String?
+        =>  if (is String key)
+            then map.defines(javaString(key))
+            else false;
+
+    shared actual
+    Item? get(Object key)
+        // don't forward non-Strings; otherwise, what to do
+        // when the arg is java.lang.String?
+        =>  if (is String key)
+            then map.get(javaString(key))
+            else null;
+
+    shared actual
+    Iterator<String->Item> iterator()
+        =>  { for (key->item in map)
+                key.string->item
+            }.iterator();
+
+    shared actual
+    Integer size
+        =>  map.size;
+
+    shared actual
+    Boolean equals(Object that)
+        =>  (super of Map<String, Item>).equals(that);
+
+    shared actual
+    Integer hash
+        =>  (super of Map<String, Item>).hash;
+}

--- a/source/ceylon/interop/java/CeylonStringMutableMap.ceylon
+++ b/source/ceylon/interop/java/CeylonStringMutableMap.ceylon
@@ -1,0 +1,37 @@
+import ceylon.collection {
+    MutableMap
+}
+
+import java.lang {
+    JString=String
+}
+
+"A [[MutableMap]] with keys of type `ceylon.language::String` that
+ wraps a `MutableMap` with keys of type `java.lang::String`.
+
+ This class can be used to wrap a `java.util::Map` if the
+ Java map is first wrapped with [[CeylonMutableMap]]:
+
+        CeylonStringMutableMap(CeylonMutableMap(javaMap))
+"
+shared
+class CeylonStringMutableMap<Item>(MutableMap<JString, Item> map)
+        extends CeylonStringMap<Item>(map)
+        satisfies MutableMap<String, Item> {
+
+    shared actual
+    void clear()
+        =>  map.clear();
+
+    shared actual
+    CeylonStringMutableMap<Item> clone()
+        =>  CeylonStringMutableMap(map.clone());
+
+    shared actual
+    Item? put(String key, Item item)
+        =>  map.put(javaString(key), item);
+
+    shared actual
+    Item? remove(String key)
+        =>  map.remove(javaString(key));
+}

--- a/test-source/test/ceylon/interop/java/interopTests.ceylon
+++ b/test-source/test/ceylon/interop/java/interopTests.ceylon
@@ -1,18 +1,31 @@
+import ceylon.collection {
+    HashMap
+}
 import ceylon.interop.java {
     ...
 }
 import ceylon.test {
     assertFalse,
     assertEquals,
-    test
+    test,
+    assertTrue,
+    assertNull
 }
 
 import java.lang {
     System {
         getSystemProperty=getProperty
-    }
+    },
+    JString=String
 }
-import java.util { ArrayList, HashSet, LinkedHashSet, TreeSet, LinkedList, Date }
+import java.util {
+    ArrayList,
+    HashSet,
+    LinkedHashSet,
+    TreeSet,
+    LinkedList,
+    Date
+}
 
 test void stringTests() {
     value val = javaString(getSystemProperty("user.home"));
@@ -49,4 +62,39 @@ test void classTests() {
     
     value klass2 = javaClass<String>();
     assertEquals("class ceylon.language.String", klass2.string);
+}
+
+test void ceylonStringMap() {
+    value jsMap = HashMap { javaString("one") -> 1, javaString("two") -> 2 };
+    value csMap = CeylonStringMap(jsMap);
+
+    assertEquals(csMap.get("one"), 1);
+    assertEquals(csMap.get("two"), 2);
+    assertTrue(csMap.defines("one"));
+    assertFalse(csMap.defines(javaString("one")));
+    assertFalse(csMap.defines("ONE"));
+    assertTrue(csMap.keys.contains("two"));
+    assertEquals(csMap.keys.size, 2);
+    assertEquals(CeylonStringMap(emptyMap).size, 0);
+}
+
+test void ceylonStringMutableMap() {
+    value jsMap = HashMap { javaString("one") -> 1 };
+    value csMap = CeylonStringMutableMap(jsMap);
+    csMap.put("two", 2);
+
+    assertEquals(jsMap.get(javaString("two")), 2);
+
+    assertEquals(csMap.get("one"), 1);
+    assertEquals(csMap.get("two"), 2);
+    assertTrue(csMap.defines("one"));
+    assertFalse(csMap.defines(javaString("one")));
+    assertFalse(csMap.defines("ONE"));
+    assertTrue(csMap.keys.contains("two"));
+    assertEquals(csMap.keys.size, 2);
+    assertEquals(CeylonStringMutableMap(
+        HashMap<JString, Object>()).size, 0);
+
+    csMap.remove("two");
+    assertNull(jsMap.get(javaString("two")));
 }


### PR DESCRIPTION
As discussed on gitter.

I thought about adding similar wrappers for other collection types, but I'm not sure if that would really be valuable, or just bloat - it's not reasonable to have wrappers for all container types for all basic types.