### PR TITLE
Fix zipFileSystem subpaths

### DIFF
--- a/source/ceylon/file/internal/ConcreteDirectory.ceylon
+++ b/source/ceylon/file/internal/ConcreteDirectory.ceylon
@@ -52,7 +52,7 @@ class ConcreteDirectory(JPath jpath)
     
     childResource(Path|String subpath) => path.childPath(subpath).resource;
     
-    move(Nil target) => ConcreteDirectory( movePath(jpath, asJPath(target.path)) );
+    move(Nil target) => ConcreteDirectory( movePath(jpath, asJPath(target.path, jpath)) );
     
     shared actual Nil delete() {
         deletePath(jpath);

--- a/source/ceylon/file/internal/ConcreteFile.ceylon
+++ b/source/ceylon/file/internal/ConcreteFile.ceylon
@@ -13,6 +13,9 @@ import java.lang {
 }
 import java.nio.file {
     JPath=Path,
+    Paths {
+        newPath=get
+    },
     Files {
         isReadable,
         isWritable,
@@ -62,26 +65,26 @@ class ConcreteFile(JPath jpath)
     }
     
     copy(Nil target, Boolean copyAttributes) =>
-            ConcreteFile( copyPath(jpath, asJPath(target.path),
+            ConcreteFile( copyPath(jpath, asJPath(target.path, jpath),
                     *(copyAttributes then [\iCOPY_ATTRIBUTES] else [])) );
     
     copyOverwriting(File|Nil target, Boolean copyAttributes) =>
-            ConcreteFile( copyPath(jpath, asJPath(target.path),
+            ConcreteFile( copyPath(jpath, asJPath(target.path, jpath),
                     *(copyAttributes then [\iREPLACE_EXISTING, \iCOPY_ATTRIBUTES ]
                                      else [\iREPLACE_EXISTING])) );
     
     move(Nil target) =>
-            ConcreteFile( movePath(jpath, asJPath(target.path)) );
+            ConcreteFile( movePath(jpath, asJPath(target.path, jpath)) );
     
     moveOverwriting(File|Nil target) =>
-            ConcreteFile( movePath(jpath, asJPath(target.path), 
+            ConcreteFile( movePath(jpath, asJPath(target.path, jpath),
                     \iREPLACE_EXISTING) );            
     
     createLink(Nil target) =>
-            ConcreteFile(newLink(asJPath(target.path), jpath));
+            ConcreteFile(newLink(asJPath(target.path, jpath), jpath));
     
     createSymbolicLink(Nil target) =>
-            ConcreteLink(newSymbolicLink(asJPath(target.path), jpath));
+            ConcreteLink(newSymbolicLink(asJPath(target.path, jpath), jpath));
     
     readable => isReadable(jpath);
     
@@ -227,4 +230,7 @@ class ConcreteFile(JPath jpath)
 }
 
 shared Boolean sameFile(File x, File y) =>
-        isSameFile(asJPath(x.path), asJPath(y.path));
+        let (xPath = x.path, yPath = y.path)
+        if (is ConcretePath xPath) then (let (jpath = xPath.jpath) isSameFile(jpath, asJPath(yPath, jpath)))
+        else if (is ConcretePath yPath) then (let (jpath = yPath.jpath) isSameFile(asJPath(xPath, jpath), jpath))
+        else isSameFile(newPath(xPath.string), newPath(yPath.string));

--- a/source/ceylon/file/internal/ConcretePath.ceylon
+++ b/source/ceylon/file/internal/ConcretePath.ceylon
@@ -55,12 +55,12 @@ shared Path[] rootPaths {
     return sb.sequence();
 }
 
-JPath asJPath(String|Path path) {
+JPath asJPath(String|Path path, JPath systemPath) {
     if (is ConcretePath path) {
         return path.jpath;
     }
     else {
-        return newPath(path.string);
+        return systemPath.fileSystem.getPath(path.string);
     }
 }
 
@@ -79,10 +79,10 @@ class ConcretePath(jpath)
     }
     
     childPath(String|Path subpath) =>
-            ConcretePath(jpath.resolve(asJPath(subpath)));
+            ConcretePath(jpath.resolve(asJPath(subpath, jpath)));
     
     siblingPath(String|Path subpath) =>
-            ConcretePath(jpath.resolveSibling(asJPath(subpath)));
+            ConcretePath(jpath.resolveSibling(asJPath(subpath, jpath)));
     
     root => jpath.nameCount==0;
     
@@ -92,12 +92,12 @@ class ConcretePath(jpath)
     
     normalizedPath => ConcretePath(jpath.normalize());
     
-    parentOf(Path path) => asJPath(path).startsWith(jpath);
+    parentOf(Path path) => asJPath(path, jpath).startsWith(jpath);
     
-    childOf(Path path) => jpath.startsWith(asJPath(path));
+    childOf(Path path) => jpath.startsWith(asJPath(path, jpath));
     
     relativePath(String|Path path) =>
-            ConcretePath(asJPath(path).relativize(jpath));
+            ConcretePath(asJPath(path, jpath).relativize(jpath));
     
     system => ConcreteSystem(jpath.fileSystem);
     
@@ -123,11 +123,11 @@ class ConcretePath(jpath)
         return sb.sequence();
     }
     
-    compare(Path other) => jpath.compareTo(asJPath(other))<=>0;
+    compare(Path other) => jpath.compareTo(asJPath(other, jpath))<=>0;
     
     shared actual Boolean equals(Object that) {
         if (is Path that) {
-            return asJPath(that)==jpath;
+            return asJPath(that, jpath)==jpath;
         }
         else {
             return false;

--- a/test-source/test/ceylon/io/testFile.ceylon
+++ b/test-source/test/ceylon/io/testFile.ceylon
@@ -1,7 +1,9 @@
 import ceylon.file {
     File,
     Path,
-    parsePath
+    parsePath,
+    Nil,
+    createZipFileSystem
 }
 import ceylon.io {
     newOpenFile,
@@ -157,4 +159,29 @@ test void testFileTruncate(){
 	
 	String ret = decoder.consume();
 	assertEquals("Hello", ret);
+}
+
+test void testZipProviderMismatchException(){
+	// create a new zip file and write to it
+	Path path = parsePath("foo.zip");
+	
+	if(is File f = path.resource){
+		// clean it up just in case
+		f.delete();
+	}
+	
+	value zip = path.resource;
+	assert(is Nil zip);
+	value system = createZipFileSystem(zip);
+	try {
+		value root = system.rootPaths.first;
+		assert(exists root);
+		root.childPath("toto");
+	} finally {
+		system.close();
+		if(is File f = path.resource){
+			// clean it up for next time
+			f.delete();
+		}
+	}
 }


### PR DESCRIPTION
The test case throws a ProviderMismatchException on openjdk 1.8, because asJPath creates JPaths using the defaut filesystem.