### PR TITLE
accepts null in json

### DIFF
--- a/source/ceylon/json/Array.ceylon
+++ b/source/ceylon/json/Array.ceylon
@@ -74,25 +74,25 @@ shared class Array({Value*} values = {})
     deleteSpan(Integer from, Integer to) 
             => list.deleteSpan(from, to);
     
-    remove(Value val) => list.remove(val);
+    remove(ObjectValue val) => list.remove(val);
     
-    removeAll({Value*} elements) => list.removeAll(elements);
+    removeAll({ObjectValue*} elements) => list.removeAll(elements);
     
-    removeFirst(Value element) => list.removeFirst(element);
+    removeFirst(ObjectValue element) => list.removeFirst(element);
     
-    removeLast(Value element) => list.removeLast(element);
+    removeLast(ObjectValue element) => list.removeLast(element);
     
     prune() => list.prune();
     
     truncate(Integer size) => list.truncate(size);
     
-    replace(Value val, Value newVal) 
+    replace(ObjectValue val, Value newVal) 
             => list.replace(val, newVal);
     
-    replaceFirst(Value element, Value replacement) 
+    replaceFirst(ObjectValue element, Value replacement) 
             => list.replaceFirst(element, replacement);
     
-    replaceLast(Value element, Value replacement) 
+    replaceLast(ObjectValue element, Value replacement) 
             => list.replaceLast(element, replacement);
     
     infill(Value replacement) => list.infill(replacement);
@@ -111,12 +111,12 @@ shared class Array({Value*} values = {})
     // auto-casting
     
     throws(`class InvalidTypeException`)
-    Object checkObject(LangObject val){
+    Object checkObject(Value val){
         if(is Object val){
             return val;
         }
         throw InvalidTypeException(
-            "Expecting Object but got `` val ``");
+            "Expecting Object but got `` val else "null" ``");
     }
 
     "Returns this array as a sequence of [[Object]] elements."
@@ -126,12 +126,12 @@ shared class Array({Value*} values = {})
             => { for (elem in list) checkObject(elem) };
 
     throws(`class InvalidTypeException`)
-    String checkString(LangObject val){
+    String checkString(Value val){
         if(is String val){
             return val;
         }
         throw InvalidTypeException(
-            "Expecting String but got `` val ``");
+            "Expecting String but got `` val else "null" ``");
     }
 
     "Returns this array as a sequence of [[String]] elements."
@@ -141,12 +141,12 @@ shared class Array({Value*} values = {})
             => { for (elem in list) checkString(elem) };
 
     throws(`class InvalidTypeException`)
-    Integer checkInteger(LangObject val){
+    Integer checkInteger(Value val){
         if(is Integer val){
             return val;
         }
         throw InvalidTypeException(
-            "Expecting Integer but got `` val ``");
+            "Expecting Integer but got `` val else "null" ``");
     }
 
     "Returns this array as a sequence of [[Integer]] elements."
@@ -156,12 +156,12 @@ shared class Array({Value*} values = {})
             => { for (elem in list) checkInteger(elem) };
 
     throws(`class InvalidTypeException`)
-    Float checkFloat(LangObject val){
+    Float checkFloat(Value val){
         if(is Float val){
             return val;
         }
         throw InvalidTypeException(
-            "Expecting Float but got `` val ``");
+            "Expecting Float but got `` val else "null" ``");
     }
 
     "Returns this array as a sequence of [[Float]] elements."
@@ -171,12 +171,12 @@ shared class Array({Value*} values = {})
             => { for (elem in list) checkFloat(elem) };
 
     throws(`class InvalidTypeException`)
-    Boolean checkBoolean(LangObject val){
+    Boolean checkBoolean(Value val){
         if(is Boolean val){
             return val;
         }
         throw InvalidTypeException(
-            "Expecting Boolean but got `` val ``");
+            "Expecting Boolean but got `` val else "null" ``");
     }
 
     "Returns this array as a sequence of [[Boolean]] elements."
@@ -186,12 +186,12 @@ shared class Array({Value*} values = {})
             => { for (elem in list) checkBoolean(elem) };
 
     throws(`class InvalidTypeException`)
-    Array checkArray(LangObject val){
+    Array checkArray(Value val){
         if(is Array val){
             return val;
         }
         throw InvalidTypeException(
-            "Expecting Array but got `` val ``");
+            "Expecting Array but got `` val else "null" ``");
     }
 
     "Returns this array as a sequence of [[Array]] elements."

--- a/source/ceylon/json/Builder.ceylon
+++ b/source/ceylon/json/Builder.ceylon
@@ -21,9 +21,8 @@ shared class Builder() satisfies Visitor {
         "The builder has not yet seen enough input to return a fully formed JSON value.")
     shared Value result {
         if (stack.size == 1,
-            ! currentKey exists,
-            exists c=stack.pop()) {
-            return c;
+            ! currentKey exists) {
+            return stack.pop();
         } else {
             throw AssertionError("currenyKey=``currentKey else "null" ``, stack=``stack``");
         }
@@ -97,8 +96,8 @@ shared class Builder() satisfies Visitor {
         push(bool);
     }
     shared actual void onNull() {
-        addToCurrent(nil);
-        push(nil);
+        addToCurrent(null);
+        push(null);
     }
     
     shared actual void onString(String string) {

--- a/source/ceylon/json/Object.ceylon
+++ b/source/ceylon/json/Object.ceylon
@@ -147,13 +147,13 @@ shared class Object({<String->Value>*} values = {})
      exist, or the value is null."
     throws(`class InvalidTypeException`,
         "If the key points to a type that is neither 
-         [[Integer]] nor [[NullInstance]].")
+         [[Integer]] nor [[Null]].")
     shared Integer? getIntegerOrNull(String key){
         value val = get(key);
         if(is Integer|Null val){
             return val;
         }
-        if(is NullInstance val){
+        if(is Null val){
             return null;
         }
         throw InvalidTypeException(
@@ -165,13 +165,13 @@ shared class Object({<String->Value>*} values = {})
      exist, or the value is null."
     throws(`class InvalidTypeException`,
         "If the key points to a type that is neither 
-         [[Float]] nor [[NullInstance]].")
+         [[Float]] nor [[Null]].")
     shared Float? getFloatOrNull(String key){
         value val = get(key);
         if(is Float|Null val){
             return val;
         }
-        if(is NullInstance val){
+        if(is Null val){
             return null;
         }
         throw InvalidTypeException(
@@ -183,13 +183,13 @@ shared class Object({<String->Value>*} values = {})
      exist, or the value is null."
     throws(`class InvalidTypeException`,
         "If the key points to a type that is neither 
-         [[Boolean]] nor [[NullInstance]].")
+         [[Boolean]] nor [[Null]].")
     shared Boolean? getBooleanOrNull(String key){
         value val = get(key);
         if(is Boolean|Null val){
             return val;
         }
-        if(is NullInstance val){
+        if(is Null val){
             return null;
         }
         throw InvalidTypeException(
@@ -201,13 +201,13 @@ shared class Object({<String->Value>*} values = {})
      exist, or the value is null."
     throws(`class InvalidTypeException`,
         "If the key points to a type that is neither 
-         [[String]] nor [[NullInstance]].")
+         [[String]] nor [[Null]].")
     shared String? getStringOrNull(String key){
         value val = get(key);
         if(is String|Null val){
             return val;
         }
-        if(is NullInstance val){
+        if(is Null val){
             return null;
         }
         throw InvalidTypeException(
@@ -219,13 +219,13 @@ shared class Object({<String->Value>*} values = {})
      exist, or the value is null."
     throws(`class InvalidTypeException`,
         "If the key points to a type that is neither 
-         [[Object]] nor [[NullInstance]].")
+         [[Object]] nor [[Null]].")
     shared Object? getObjectOrNull(String key){
         value val = get(key);
         if(is Object|Null val){
             return val;
         }
-        if(is NullInstance val){
+        if(is Null val){
             return null;
         }
         throw InvalidTypeException(
@@ -237,13 +237,13 @@ shared class Object({<String->Value>*} values = {})
      exist, or the value is null."
     throws(`class InvalidTypeException`,
         "If the key points to a type that is neither 
-         [[Array]] nor [[NullInstance]].")
+         [[Array]] nor [[Null]].")
     shared Array? getArrayOrNull(String key){
         value val = get(key);
         if(is Array|Null val){
             return val;
         }
-        if(is NullInstance val){
+        if(is Null val){
             return null;
         }
         throw InvalidTypeException(

--- a/source/ceylon/json/Printer.ceylon
+++ b/source/ceylon/json/Printer.ceylon
@@ -1,7 +1,3 @@
-import ceylon.language {
-    Obj=Object
-}
-
 "A JSON Printer"
 by("Stéphane Épardaud")
 shared abstract class Printer(Boolean pretty = false){
@@ -137,12 +133,12 @@ shared abstract class Printer(Boolean pretty = false){
         case (is Array){
             printArray(val);
         }
-        case (is NullInstance){
+        case (is Null){
             printNull();
         }
     }
     
 }
 
-Comparison compareKeys(String->Obj x, String->Obj y)
+Comparison compareKeys(String->Value x, String->Value y)
         => x.key<=>y.key; 

--- a/source/ceylon/json/Value.ceylon
+++ b/source/ceylon/json/Value.ceylon
@@ -1,6 +1,13 @@
 "A JSON value, a [[String]], [[Boolean]], [[Integer]],
- [[Float]], JSON [[Object]], JSON [[Array]], or a
- [[null value|nil]]."
+ [[Float]], JSON [[Object]], JSON [[Array]], or 
+ [[Null]]."
 shared alias Value 
-        => String | Boolean | Integer | Float |
-           Object | Array | NullInstance;
+        => ObjectValue|Null;
+
+"A JSON value, a [[String]], [[Boolean]], [[Integer]],
+ [[Float]], JSON [[Object]], or JSON [[Array]].
+ 
+ This means [[Value]] except [[Null]]."
+shared alias ObjectValue
+		=> String | Boolean | Integer | Float |
+		Object | Array;

--- a/source/ceylon/json/Visitor.ceylon
+++ b/source/ceylon/json/Visitor.ceylon
@@ -78,7 +78,7 @@ shared void visit(subject, visitor, sortedKeys=false) {
     case (is Boolean) {
         visitor.onBoolean(subject);
     }
-    case (is NullInstance) {
+    case (is Null) {
         visitor.onNull();
     }
 }

--- a/source/ceylon/json/nullInstance.ceylon
+++ b/source/ceylon/json/nullInstance.ceylon
@@ -1,7 +1,0 @@
-"Represents the type of the `null` value in JSON."
-shared abstract class NullInstance() of nil {}
-
-"The singleton that represents the `null` value in JSON`."
-shared object nil extends NullInstance() {
-    shared actual String string = "null";
-}

--- a/test-source/test/ceylon/json/parse.ceylon
+++ b/test-source/test/ceylon/json/parse.ceylon
@@ -789,7 +789,7 @@ String herdJson = """
                      """;
 
 shared test void testParse() {
-    assert(is NullInstance nu = parse("null"));
+    assert(is Null nu = parse("null"));
     assert(is Boolean b1 = parse("true"), b1);
     assert(is Boolean b2 = parse("false"), !b2);
     try {
@@ -820,8 +820,8 @@ shared test void testParse() {
         throw;
     } catch (ParseException p) {
     }
-    
-    assert(is Float n0 = parse("1"));
+
+    assert(is Integer n0 = parse("1"));
     assertEquals(1, n0);
     
     assert(is Float n1 = parse("123.0"));
@@ -878,7 +878,7 @@ shared test void testParse() {
     assertEquals("bar", o3["s"]);
     assertEquals(true, o3["t"]);
     assertEquals(false, o3["f"]);
-    assertEquals(nil, o3["n"]);
+    assertEquals(null, o3["n"]);
     
     assert(is Object o4 = parse("{\"i\": 12, \"f\": 12.34, \"ie\": 12e10, \"fe\": 12.34e10}"));
     assertEquals(4, o4.size);
@@ -947,7 +947,7 @@ shared test void testParse() {
 	assertEquals("https://github.com/ceylon/ceylon-compiler", o12["html_url"]);
     assertEquals(1287859, o12["id"]);
 	assertEquals("Java", o12["language"]);
-    assertEquals(nil, o12["mirror_url"]);
+    assertEquals(null, o12["mirror_url"]);
 	assertEquals("ceylon-compiler", o12["name"]);
     assertEquals(81, o12["open_issues"]);
     if(is Object org = o12["organization"]){

--- a/test-source/test/ceylon/json/print.ceylon
+++ b/test-source/test/ceylon/json/print.ceylon
@@ -1,4 +1,4 @@
-import ceylon.json { Object, Array, nil }
+import ceylon.json { Object, Array }
 import ceylon.test { assertEquals, test }
 
 shared test void testPrint(){
@@ -11,7 +11,7 @@ shared test void testPrint(){
         "f" -> 12.34,
         "true" -> true,
         "false" ->false,
-        "null" -> nil,
+        "null" -> null,
         "o" -> Object{
             values=["i" -> 2];
         },

--- a/test-source/test/ceylon/json/use.ceylon
+++ b/test-source/test/ceylon/json/use.ceylon
@@ -4,8 +4,8 @@ void testUsage(){
     value json = parse("""{"svn_url":"https://github.com/ceylon/ceylon-compiler","has_downloads":true,"homepage":"http://ceylon-lang.org","mirror_url":null,"has_issues":true,"updated_at":"2012-04-11T10:20:59Z","forks":22,"clone_url":"https://github.com/ceylon/ceylon-compiler.git","ssh_url":"git@github.com:ceylon/ceylon-compiler.git","html_url":"https://github.com/ceylon/ceylon-compiler","language":"Java","organization":{"gravatar_id":"a38479e9dc888f68fb6911d4ce05d7cc","url":"https://api.github.com/users/ceylon","avatar_url":"https://secure.gravatar.com/avatar/a38479e9dc888f68fb6911d4ce05d7cc?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-orgs.png","id":579261,"login":"ceylon"},"has_wiki":true,"fork":false,"git_url":"git://github.com/ceylon/ceylon-compiler.git","created_at":"2011-01-24T14:25:50Z","url":"https://api.github.com/repos/ceylon/ceylon-compiler","size":2413,"private":false,"open_issues":81,"description":"Ceylon compiler (ceylonc: Java backend), Ceylon documentation generator (ceylond) and Ceylon ant tasks.","owner":{"gravatar_id":"a38479e9dc888f68fb6911d4ce05d7cc","url":"https://api.github.com/users/ceylon","avatar_url":"https://secure.gravatar.com/avatar/a38479e9dc888f68fb6911d4ce05d7cc?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-orgs.png","id":579261,"login":"ceylon"},"name":"ceylon-compiler","watchers":74,"pushed_at":"2012-04-11T07:43:33Z","id":1287859}""");
     assert(is Object json);
 
-    for(key->item in json.sort((Entry<String,String|Boolean|Integer|Float|Object|Array|NullInstance> x, Entry<String,String|Boolean|Integer|Float|Object|Array|NullInstance> y) => x.key.compare(y.key))){
-        print("``key`` -> ``item``");
+    for(key->item in json.sort((Entry<String,String|Boolean|Integer|Float|Object|Array|Null> x, Entry<String,String|Boolean|Integer|Float|Object|Array|Null> y) => x.key.compare(y.key))){
+        print("``key`` -> ``item else "null"``");
     }
     
     if(json.getInteger("open_issues") > 0){


### PR DESCRIPTION
This change is for #316 and uses Null type instead of NullInstance, but i wasnt able to make it totally transparent because some methods like ```remove, removeAll, removeFirst, removeLast, replace, replaceFirst and  replaceLast``` doesn not accept Null. As workaround I create ObjectValue that means Value except Null type.

Ps.: I had a problem with parse("1") that now only accepts assert(is Integer) instead of assert(is Float).. is this right?