### PR TITLE
Fix NPE in Nil.createFile(true)

### DIFF
--- a/source/ceylon/file/internal/ConcreteNil.ceylon
+++ b/source/ceylon/file/internal/ConcreteNil.ceylon
@@ -23,8 +23,8 @@ class ConcreteNil(JPath jpath)
     }
     
     shared actual File createFile(Boolean includingParentDirectories) {
-        if( includingParentDirectories ) {
-            newDirectories(jpath.parent);
+        if( includingParentDirectories, exists parent = jpath.parent ) {
+            newDirectories(parent);
         }
         return ConcreteFile(newFile(jpath));
     }


### PR DESCRIPTION
The following program could be used to reproduce the exception:

```ceylon
import ceylon.file {
    parsePath,
    Nil
}
shared void run() {
    assert (is Nil r = parsePath("foo").resource);
    r.createFile { includingParentDirectories = true; };
}
```

`createFile(true)` would attempt to create the parent directories even if the path had no parent directories, resulting in a `NullPointerException` somewhere in `java.nio.Files`.