### PR TITLE
Logging minor changes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -104,6 +104,7 @@
             <module name="test.ceylon.unicode"/>
             <module name="test.ceylon.html"/>
             <module name="test.ceylon.locale"/>
+            <module name="test.ceylon.logging"/>
             <module name="test.ceylon.regex"/>
             <module name="test.ceylon.transaction"/>
         </moduleset>

--- a/source/ceylon/logging/Priority.ceylon
+++ b/source/ceylon/logging/Priority.ceylon
@@ -30,7 +30,7 @@ shared object debug extends Priority("DEBUG",60) {}
 
 "An event that is only interesting when the programmer is
  pulling out hair while debugging the program."
-shared object trace extends Priority("FINE",50) {}
+shared object trace extends Priority("TRACE",50) {}
 
 "The default [[Priority]] for newly created [[Logger]]s. 
  This priority is inherited by all other loggers which do 


### PR DESCRIPTION
- Change string for `trace` to `TRACE` (was `FINE`)
- Add `test.ceylon.logging` to the ant build

I guess there could be reasons these were the way the were. If so, just close this.