### PR TITLE
Add stdio FileDescriptors

### DIFF
--- a/source/ceylon/io/FileDescriptor.ceylon
+++ b/source/ceylon/io/FileDescriptor.ceylon
@@ -2,15 +2,15 @@ import ceylon.io.buffer {
     ByteBuffer
 }
 
-"Represents anything that you can read/write to, much like 
- the UNIX notion of file descriptor.
- 
- This supports synchronous and asynchronous reading."
-see(`interface Socket`,
-    `interface SelectableFileDescriptor`)
-by("Stéphane Épardaud")
-shared sealed interface FileDescriptor {
+shared sealed interface Closeable {
+    "Closes this file descriptor."
+    shared formal void close();
+}
 
+"Represents anything that you can read from, much like
+ the UNIX notion of file descriptor."
+by("Stéphane Épardaud")
+shared sealed interface ReadableFileDescriptor satisfies Closeable {
     "Reads everything we can from this file descriptor into 
      the specified buffer.
      
@@ -32,7 +32,7 @@ shared sealed interface FileDescriptor {
      This method makes no sense if the file descriptor is in
      `non-blocking` mode."
     shared void readFully(void consume(ByteBuffer buffer), 
-            ByteBuffer buffer = newBuffer()) {
+        ByteBuffer buffer = newBuffer()) {
         // FIXME: should we allocate the buffer ourselves?
         // FIXME: should we clear the buffer passed?
         // I guess not, because there might be something left 
@@ -53,7 +53,12 @@ shared sealed interface FileDescriptor {
             buffer.clear();
         }
     }
-    
+}
+
+"Represents anything that you can write to, much like
+ the UNIX notion of file descriptor."
+by("Stéphane Épardaud")
+shared sealed interface WritableFileDescriptor satisfies Closeable {
     "Writes everything we can from the specified buffer to 
      this file descriptor.
      
@@ -69,7 +74,7 @@ shared sealed interface FileDescriptor {
      In both cases, it returns the number of bytes written, 
      or `-1` when the end of file is reached."
     shared formal Integer write(ByteBuffer buffer);
-
+    
     "Writes the given buffer to this file descriptor 
      entirely, until either the buffer has been entirely 
      written, or until end of file. This method makes no 
@@ -86,7 +91,7 @@ shared sealed interface FileDescriptor {
      it only has to stop adding data to the buffer. This
      method makes no sense in `non-blocking` mode."
     shared void writeFrom(void producer(ByteBuffer buffer), 
-            ByteBuffer buffer = newBuffer()) {
+        ByteBuffer buffer = newBuffer()) {
         // refill
         while(true) {
             // fill our buffer
@@ -101,7 +106,15 @@ shared sealed interface FileDescriptor {
             buffer.clear();
         }
     }
-    
-    "Closes this file descriptor."
-    shared formal void close();
+}
+
+"Represents anything that you can read/write to, much like 
+ the UNIX notion of file descriptor.
+ 
+ This supports synchronous and asynchronous reading."
+see (`interface Socket`,
+    `interface SelectableFileDescriptor`)
+by ("Stéphane Épardaud")
+shared sealed interface FileDescriptor
+        satisfies ReadableFileDescriptor & WritableFileDescriptor {
 }

--- a/source/ceylon/io/impl/InputStreamAdapter.ceylon
+++ b/source/ceylon/io/impl/InputStreamAdapter.ceylon
@@ -1,0 +1,28 @@
+import ceylon.io {
+    ReadableFileDescriptor
+}
+import ceylon.io.buffer {
+    ByteBuffer
+}
+
+import java.io {
+    InputStream
+}
+import java.nio {
+    JavaByteBuffer=ByteBuffer
+}
+import java.nio.channels {
+    ReadableByteChannel,
+    Channels
+}
+
+shared class InputStreamAdapter(InputStream stream) satisfies ReadableFileDescriptor {
+    ReadableByteChannel channel = Channels.newChannel(stream);
+    
+    shared actual void close() => channel.close();
+    
+    shared actual Integer read(ByteBuffer buffer) {
+        assert (is JavaByteBuffer implementation = buffer.implementation);
+        return channel.read(implementation);
+    }
+}

--- a/source/ceylon/io/impl/OutputStreamAdapter.ceylon
+++ b/source/ceylon/io/impl/OutputStreamAdapter.ceylon
@@ -1,0 +1,28 @@
+import ceylon.io {
+    WritableFileDescriptor
+}
+import ceylon.io.buffer {
+    ByteBuffer
+}
+
+import java.io {
+    OutputStream
+}
+import java.nio {
+    JavaByteBuffer=ByteBuffer
+}
+import java.nio.channels {
+    WritableByteChannel,
+    Channels
+}
+
+shared class OutputStreamAdapter(OutputStream stream) satisfies WritableFileDescriptor {
+    WritableByteChannel channel = Channels.newChannel(stream);
+    
+    shared actual void close() => channel.close();
+    
+    shared actual Integer write(ByteBuffer buffer) {
+        assert (is JavaByteBuffer implementation = buffer.implementation);
+        return channel.write(implementation);
+    }
+}

--- a/source/ceylon/io/stdio.ceylon
+++ b/source/ceylon/io/stdio.ceylon
@@ -12,10 +12,13 @@ import java.lang {
 }
 
 "A [[ReadableFileDescriptor]] for the virtual machine's standard input stream."
-ReadableFileDescriptor stdin = InputStreamAdapter(javaIn);
+aliased("stdin")
+ReadableFileDescriptor standardInput = InputStreamAdapter(javaIn);
 
 "A [[WritableFileDescriptor]] for the virtual machine's standard output stream."
-WritableFileDescriptor stdout = OutputStreamAdapter(javaOut);
+aliased("stdout")
+WritableFileDescriptor standardOutput = OutputStreamAdapter(javaOut);
 
 "A [[WritableFileDescriptor]] for the virtual machine's standard error stream."
-WritableFileDescriptor stderr = OutputStreamAdapter(javaErr);
+aliased("stderr")
+WritableFileDescriptor standardError = OutputStreamAdapter(javaErr);

--- a/source/ceylon/io/stdio.ceylon
+++ b/source/ceylon/io/stdio.ceylon
@@ -1,0 +1,21 @@
+import ceylon.io.impl {
+    InputStreamAdapter,
+    OutputStreamAdapter
+}
+
+import java.lang {
+    System {
+        javaIn=\iin,
+        javaOut=\iout,
+        javaErr=err
+    }
+}
+
+"A [[ReadableFileDescriptor]] for the virtual machine's standard input"
+ReadableFileDescriptor stdin = InputStreamAdapter(javaIn);
+
+"A [[WritableFileDescriptor]] for the virtual machine's standard output stream."
+WritableFileDescriptor stdout = OutputStreamAdapter(javaOut);
+
+"A [[WritableFileDescriptor]] for the virtual machine's standard error stream."
+WritableFileDescriptor stderr = OutputStreamAdapter(javaErr);

--- a/source/ceylon/io/stdio.ceylon
+++ b/source/ceylon/io/stdio.ceylon
@@ -11,7 +11,7 @@ import java.lang {
     }
 }
 
-"A [[ReadableFileDescriptor]] for the virtual machine's standard input"
+"A [[ReadableFileDescriptor]] for the virtual machine's standard input stream."
 ReadableFileDescriptor stdin = InputStreamAdapter(javaIn);
 
 "A [[WritableFileDescriptor]] for the virtual machine's standard output stream."


### PR DESCRIPTION
As prompted by [discussion](https://gitter.im/ceylon/user/archives/2015/10/31) with @ePaul et al., this PR adds (JVM-only) stdio support to `ceylon.io`.

Since these streams are unidirectional, I have refactored the `FileDescriptor` interface to support this.