### PR TITLE
support empty attribute values in ceylon.html

### DIFF
--- a/source/ceylon/html/A.ceylon
+++ b/source/ceylon/html/A.ceylon
@@ -3,7 +3,7 @@
  
  Technical details about this element can be found on the
  [Official W3C reference](http://dev.w3.org/html5/spec/Overview.html#the-a-element)"
-shared class A(text = "", href = "#", target = null, download = null,
+shared class A(text = "", href = null, target = null, download = null,
             hrefLang = null, rel = null, type = null,
             String? id = null, CssClass classNames = [],
             String? style = null, String? accessKey = null,
@@ -24,7 +24,7 @@ shared class A(text = "", href = "#", target = null, download = null,
     shared actual String text;
 
     "Specifies the URL of the page the link goes to."
-    shared String href;
+    shared String? href;
 
     "If present, must be a valid browsing context name or keyword.
      It gives the name of the browsing context that will be used."

--- a/source/ceylon/html/Element.ceylon
+++ b/source/ceylon/html/Element.ceylon
@@ -32,9 +32,13 @@ shared abstract class StyledElement(String? id, classNames = [], style = null)
     shared actual default [<String->Object>*] attributes {
         value attrs = AttributeSequenceBuilder();
         attrs.addAll(super.attributes);
-        if (is String[] classNames) {
-            attrs.addAttribute("class", " ".join(classNames));
-        } else {
+        switch (classNames)
+        case (is String[]) {
+            if (!classNames.empty) {
+                attrs.addAttribute("class", " ".join(classNames));
+            }
+        }
+        case (is String) {
             attrs.addAttribute("class", classNames);
         }
         attrs.addAttribute("style", style);

--- a/source/ceylon/html/Form.ceylon
+++ b/source/ceylon/html/Form.ceylon
@@ -5,7 +5,7 @@
  
  Technical details about this element can be found on the
  [Official W3C reference](http://dev.w3.org/html5/spec/Overview.html#the-form-element)"
-shared class Form(action, method = "", acceptCharset = null,
+shared class Form(action, method = null, acceptCharset = null,
             autoComplete = null, encType = null, name = null,
             noValidate = null, target = null,
             String? id = null, CssClass classNames = [],
@@ -30,7 +30,7 @@ shared class Form(action, method = "", acceptCharset = null,
 
     "Specifies the HTTP method to use when
      sending form-data"
-    shared String method; // TODO enumerated type
+    shared String? method; // TODO enumerated type
 
     "Specifies the character encodings that are
      to be used for the form submission."

--- a/source/ceylon/html/Img.ceylon
+++ b/source/ceylon/html/Img.ceylon
@@ -4,7 +4,7 @@
  
  Technical details about this element can be found on the
  [Official W3C reference](http://dev.w3.org/html5/spec/Overview.html#the-img-element)"
-shared class Img(src, alt = "", useMap = null,
+shared class Img(src, alt = null, useMap = null,
             isMap = null, width = null, height = null,
             String? id = null, CssClass classNames = [],
             String? style = null, String? accessKey = null,
@@ -26,7 +26,7 @@ shared class Img(src, alt = "", useMap = null,
 
     "Provides equivalent content for those who cannot process
      images or who have image loading disabled"
-    shared String alt;
+    shared String? alt;
     
     //crossorigin TODO understand this attribute better (enumerable?)
 

--- a/source/ceylon/html/Meta.ceylon
+++ b/source/ceylon/html/Meta.ceylon
@@ -6,22 +6,24 @@
  Technical details about this element can be found on the
  [Official W3C reference](http://dev.w3.org/html5/spec/Overview.html#meta)"
 see(`class CharsetMeta`)
-shared class Meta(name, content = "", String? id = null)
+shared class Meta(name, content = null, String? id = null)
         extends Element(id) {
 
     "The name (key) of the metadata."
     shared String name;
 
     "The content (value) of the metadata."
-    shared String content;
+    shared String? content;
 
     tag = Tag("meta", emptyTag);
-    
-    shared actual default [<String->Object>*] attributes => concatenate(super.attributes, [
-        "name"->name,
-        "content"->content
-    ]);
 
+    shared actual default [<String->Object>*] attributes {
+        value attrs = AttributeSequenceBuilder();
+        attrs.addAttribute("name", name);
+        attrs.addAttribute("content", content);
+        attrs.addAll(super.attributes);
+        return attrs.sequence();
+    }
 }
 
 "Utility class to easily express a charset metadata for the [[Document]]."

--- a/source/ceylon/html/layout/BaseLayout.ceylon
+++ b/source/ceylon/html/layout/BaseLayout.ceylon
@@ -17,7 +17,7 @@ shared class BaseLayout(title, body = Div()) satisfies Layout {
     shared String title;
 
     "The page meta description."
-    shared default String description = "";
+    shared default String? description = null;
 
     shared default {Script*} headScripts = {};
 
@@ -39,7 +39,7 @@ shared class BaseLayout(title, body = Div()) satisfies Layout {
             headChildren = concatenate(
                 {
                     CharsetMeta(),
-                    Meta("description", description)
+                    Meta("description", null)
                 },
                 //stylesheets,
                 headScripts

--- a/source/ceylon/html/serializer/NodeSerializer.ceylon
+++ b/source/ceylon/html/serializer/NodeSerializer.ceylon
@@ -67,11 +67,8 @@ shared class NodeSerializer(
                 then node.attributes
                 else {};
 
-        // for now, duplicate bug that drops attributes
-        // with empty value
         value nonEmptyAttributes = attributes
-            .map((attribute) => attribute.key->attribute.item.string)
-            .filter((attribute) => !attribute.item.empty);
+            .map((attribute) => attribute.key->attribute.item.string);
 
         htmlSerializer.startElement(node.tag.name, nonEmptyAttributes);
     }

--- a/test-source/test/ceylon/html/serialization.ceylon
+++ b/test-source/test/ceylon/html/serialization.ceylon
@@ -19,7 +19,8 @@ import ceylon.html {
     Pre,
     Cite,
     Strong,
-    P
+    P,
+    A
 }
 import ceylon.html.serializer {
     NodeSerializer,
@@ -234,6 +235,15 @@ void testAttributeValue() {
     test(Div { nonstandardAttributes = ["att"->"multi\nline"]; }, "<div att=\"multi\nline\"></div>");
     test(Div { nonstandardAttributes = ["att"->"trailing sp "]; }, "<div att=\"trailing sp \"></div>");
     test(Div { nonstandardAttributes = ["att"->" leading sp"]; }, "<div att=\" leading sp\"></div>");
+}
+
+shared test
+void testEmptyAttribute() {
+    function test(Node actual, String expected)
+            =>  runTest(actual, expected, false, false);
+    
+    test(Div { nonstandardAttributes = ["att"->""]; }, "<div att=\"\"></div>");
+    test(A { href = ""; }, "<a href=\"\"></a>");
 }
 
 shared test


### PR DESCRIPTION
For #404

This is a breaking change (to some extent) and it's difficult to be certain that I caught all cases of `""` being used to indicate that an attribute should be excluded, but I think it is a good change to have since the html 5 spec does allow attributes with no value.