### PR TITLE
JS interop with web browsers.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -84,7 +84,7 @@
             <module name="ceylon.regex"/>
             <module name="ceylon.test"/>
             <module name="ceylon.time"/>
-        	<module name="ceylon.interop.browser"/>
+            <module name="ceylon.interop.browser"/>
         </moduleset>
 	
         <moduleset id="modules.test.jvm">

--- a/build.xml
+++ b/build.xml
@@ -84,6 +84,7 @@
             <module name="ceylon.regex"/>
             <module name="ceylon.test"/>
             <module name="ceylon.time"/>
+        	<module name="ceylon.interop.browser"/>
         </moduleset>
 	
         <moduleset id="modules.test.jvm">

--- a/source/ceylon/interop/browser/Window.ceylon
+++ b/source/ceylon/interop/browser/Window.ceylon
@@ -1,0 +1,170 @@
+import ceylon.interop.browser.dom {
+    GlobalEventHandlers,
+    WindowEventHandlers,
+    EventHandler,
+    EventTarget,
+    Element,
+    Document
+}
+
+// TODO doc
+
+"See http://www.w3.org/TR/html5/browsers.html#the-window-object"
+shared dynamic Window satisfies EventTarget & WindowEventHandlers & GlobalEventHandlers {
+    
+    shared formal WindowProxy window;
+    shared formal WindowProxy self;
+    shared formal Document document;
+    shared formal variable String name;
+    shared formal Location location;
+    shared formal History history;
+    
+    shared formal BarProp locationbar;
+    shared formal BarProp menubar;
+    shared formal BarProp personalbar;
+    shared formal BarProp scrollbars;
+    shared formal BarProp statusbar;
+    shared formal BarProp toolbar;
+    shared formal variable String status;
+    shared formal void close();
+    shared formal Boolean closed;
+    shared formal void stop();
+    shared formal void focus();
+    shared formal void blur();
+    shared formal WindowProxy frames;
+    shared formal Integer length;
+    shared formal WindowProxy top;
+    shared formal WindowProxy? opener;
+    shared formal WindowProxy parent;
+    shared formal Element? frameElement;
+    shared formal WindowProxy open(String url = "about:blank",
+        String target = "_blank", String features = "", Boolean replace = false);
+    
+    // TODO getter WindowProxy (unsigned long index);
+    // TODO getter object (DOMString name);
+    
+    shared formal Navigator navigator;
+    shared formal External external;
+    shared formal ApplicationCache applicationCache;
+    shared formal void alert(String message = "");
+    shared formal Boolean confirm(String message = "");
+    shared formal String? prompt(String message = "", String default = "");
+    shared formal void print();
+}
+
+shared alias WindowProxy => Window;
+
+"The current window."
+shared Window window {
+    dynamic {
+        return eval("window");
+    }
+}
+
+"Provide a representation of the address of the active document of the
+ [[Document]]'s browsing context, and allow the current entry of the browsing
+ context's session history to be changed, by adding or replacing entries
+ in the [[History]] object."
+shared dynamic Location {
+    "Navigates to the given page."
+    shared formal void \iassign(String url);
+    
+    "Removes the current page from the session history and navigates to
+     the given page."
+    shared formal void replace(String url);
+    
+    "Reloads the current page."
+    shared formal void reload();
+}
+
+shared dynamic History {
+    "Returns the number of entries in the joint session history."
+    shared formal Integer length;
+    
+    "Returns the current state object."
+    shared formal dynamic state;
+    
+    "Goes back or forward the specified number of steps in the joint session history.
+    
+     A zero delta will reload the current page.
+    
+     If the delta is out of range, does nothing."
+    shared formal void go(Integer delta);
+    
+    "Goes back one step in the joint session history.
+    
+     If there is no previous page, does nothing."
+    shared formal void back();
+    
+    "Goes forward one step in the joint session history.
+    
+     If there is no next page, does nothing."
+    shared formal void forward();
+    
+    "Pushes the given data onto the session history, with the given title,
+     and, if provided and not null, the given URL."
+    shared formal void pushState(dynamic data, String title, String? url = null);
+    
+    "Updates the current entry in the session history to have the given data,
+     title, and, if provided and not null, URL."
+    shared formal void replaceState(dynamic data, String title, String? url = null);
+}
+
+"Represents the visibility of a bar in the browser (toolbar, address bar,
+ scrollbar etc)."
+shared dynamic BarProp {
+    shared formal variable Boolean visible;
+}
+
+"http://www.w3.org/TR/html5/webappapis.html#external"
+shared dynamic External {
+    "Adds the search engine described by the OpenSearch description document at url.
+    
+     The OpenSearch description document has to be on the same server as the
+     script that calls this method."
+    shared formal void \iAddSearchProvider(String engineURL);
+    
+    "Returns a value based on comparing url to the URLs of the results pages
+     of the installed search engines:
+     
+     * `0`: None of the installed search engines match `engineURL`.
+     * `1`: One or more installed search engines match `engineURL`, but none are
+     the user's default search engine.
+     * `2`: The user's default search engine matches `engineURL`.
+     
+     The `engineUrl` is compared to the URLs of the results pages of the installed
+     search engines using a prefix match. Only results pages on the same domain
+     as the script that calls this method are checked."
+    shared formal Integer \iIsSearchProviderInstalled(String engineURL);
+}
+
+// TODO
+shared dynamic Navigator {
+}
+
+// TODO doc
+shared dynamic ApplicationCache satisfies EventTarget {
+    // update status
+    shared formal Integer \iUNCACHED;
+    shared formal Integer \iIDLE;
+    shared formal Integer \iCHECKING;
+    shared formal Integer \iDOWNLOADING;
+    shared formal Integer \iUPDATEREADY;
+    shared formal Integer \iOBSOLETE;
+    shared formal Integer status;
+    
+    // updates
+    shared formal void update();
+    shared formal void abort();
+    shared formal void swapCache();
+    
+    // events
+    shared formal variable EventHandler? onchecking;
+    shared formal variable EventHandler? onerror;
+    shared formal variable EventHandler? onnoupdate;
+    shared formal variable EventHandler? ondownloading;
+    shared formal variable EventHandler? onprogress;
+    shared formal variable EventHandler? onupdateready;
+    shared formal variable EventHandler? oncached;
+    shared formal variable EventHandler? onobsolete;
+}

--- a/source/ceylon/interop/browser/XMLHttpRequest.ceylon
+++ b/source/ceylon/interop/browser/XMLHttpRequest.ceylon
@@ -1,0 +1,157 @@
+import ceylon.interop.browser.dom {
+    EventHandler,
+    EventTarget,
+    Document
+}
+import ceylon.interop.browser.internal {
+    newXMLHttpRequestInternal
+}
+
+"Defines an API that provides scripted client functionality for
+ transferring data between a client and a server.
+ 
+ See [http://www.w3.org/TR/XMLHttpRequest/](http://www.w3.org/TR/XMLHttpRequest/)"
+shared dynamic XMLHttpRequest satisfies XMLHttpRequestEventTarget {
+    // event handler
+    "Dispatched when the [[readyState]] attribute changes value, except
+     when it changes to [[UNSENT]]."
+    shared formal variable EventHandler? onreadystatechange;
+    
+    // states
+    "The object has been constructed."
+    shared formal Integer \iUNSENT;
+    
+    "The [[open]] method has been successfully invoked.
+     During this state request headers can be set using [[setRequestHeader]]
+     and the request can be made using the [[send]] method."
+    shared formal Integer \iOPENED;
+    
+    "All redirects (if any) have been followed and all HTTP headers of the
+     final response have been received. Several response members of the object
+     are now available."
+    shared formal Integer \iHEADERS_RECEIVED;
+    
+    "The response entity body is being received."
+    shared formal Integer \iLOADING;
+    
+    "The data transfer has been completed or something went wrong during
+     the transfer (e.g. infinite redirects)."
+    shared formal Integer \iDONE;
+    
+    "Returns the current state."
+    shared formal Integer readyState;
+    
+    // request
+    "Sets the [[request method|method]], [[request URL|url]], and
+     [[synchronous flag|async]]."
+    shared formal void open(String method, String url,
+        Boolean async = false, String? username = null, String? password = null);
+    
+    "Appends an header to the list of author request headers, or if header
+     is already in the list of author request headers, combines its value
+     with value."
+    shared formal void setRequestHeader(String header, String val);
+    
+    "Can be set to a time in milliseconds. When set to a non-zero value
+     will cause fetching to terminate after the given time has passed.
+     When the time has passed, the request has not yet completed, and the
+     synchronous flag is unset, a timeout event will then be dispatched,
+     or a `TimeoutError` exception will be thrown otherwise
+     (for the send() method)."
+    shared formal variable Integer timeout;
+    
+    "True when user credentials are to be included in a cross-origin request.
+     False when they are to be excluded in a cross-origin request and when
+     cookies are to be ignored in its response. Initially false."
+    shared formal variable Boolean withCredentials;
+    
+    "Returns the associated XMLHttpRequestUpload object. It can be used
+     to gather transmission information when data is transferred to a server."
+    shared formal XMLHttpRequestUpload upload;
+    
+    "Initiates the request. The optional argument provides the request
+     entity body. The argument is ignored if request method is `GET` or `HEAD`."
+    // TODO (ArrayBufferView or Blob or Document or [EnsureUTF16] DOMString or FormData)
+    shared formal void send(String? data = null);
+    
+    "Cancels any network activity."
+    shared formal void abort();
+    
+    // response
+    "Returns the HTTP status code."
+    shared formal Integer status;
+    
+    "Returns the HTTP status text."
+    shared formal String statusText;
+    
+    "Returns the header field value from the response of which the field name
+     matches header, unless the field name is `Set-Cookie` or `Set-Cookie2`."
+    shared formal String? getResponseHeader(String header);
+    
+    "Returns all headers from the response, with the exception of those whose
+     field name is `Set-Cookie` or `Set-Cookie2`."
+    shared formal String getAllResponseHeaders();
+    
+    "Sets the `Content-Type` header for the response to mime."
+    shared formal void overrideMimeType(String mime);
+    
+    "Returns the response type.
+    
+     Can be set to change the response type.
+     Possible values are defined in [[XMLHttpRequestResponseType]]"
+    see (`interface XMLHttpRequestResponseType`)
+    shared formal String responseType;
+    
+    "Returns the response entity body."
+    shared formal dynamic response;
+    
+    "Returns the text response entity body."
+    shared formal String responseText;
+    
+    "Returns the document response entity body."
+    shared formal Document? responseXml;
+}
+
+"Creates a new instance of [[XMLHttpRequest]]."
+shared XMLHttpRequest newXMLHttpRequest()
+        => newXMLHttpRequestInternal();
+
+shared dynamic XMLHttpRequestEventTarget satisfies EventTarget {
+    // event handlers
+    "Dispatched when the request starts."
+    shared formal variable EventHandler? onloadstart;
+    
+    "Dispatched when transmitting data."
+    shared formal variable EventHandler? onprogress;
+    
+    "Dispatched when the request has been aborted. For instance,
+     by invoking the `abort()` method."
+    shared formal variable EventHandler? onabort;
+    
+    "Dispatched when the request has failed."
+    shared formal variable EventHandler? onerror;
+    
+    "Dispatched when the request has successfully completed."
+    shared formal variable EventHandler? onload;
+    
+    "Dispatched when the author specified timeout has passed before
+     the request completed."
+    shared formal variable EventHandler? ontimeout;
+    
+    "Dispatched when the request has completed (either in success or failure)."
+    shared formal variable EventHandler? onloadend;
+}
+
+"Used to gather transmission information when data is transferred to a server."
+shared dynamic XMLHttpRequestUpload satisfies XMLHttpRequestEventTarget {
+}
+
+"Possible values for [[XMLHttpRequest.responseType]]."
+shared interface XMLHttpRequestResponseType {
+    shared String empty => "";
+    shared String arrayBuffer => "arraybuffer";
+    shared String blob => "blob";
+    shared String document => "document";
+    shared String json => "json";
+    shared String text => "text";
+}

--- a/source/ceylon/interop/browser/dom/events.ceylon
+++ b/source/ceylon/interop/browser/dom/events.ceylon
@@ -1,0 +1,152 @@
+import ceylon.interop.browser.internal {
+    newEventInternal
+}
+
+"An object to which an event is dispatched when something has occurred.
+ Each EventTarget has an associated list of event listeners."
+shared dynamic EventTarget {
+    
+    "Appends an event listener for events whose type attribute value is [[type]].
+     The [[callback]] argument sets the callback that will be invoked when the
+     event is dispatched. When set to `true`, the [[capture]] argument prevents
+     callback from being invoked when the event’s `eventPhase` attribute value
+     is `BUBBLING_PHASE`. When false, callback will not be invoked when
+     event’s `eventPhase` attribute value is `CAPTURING_PHASE`. Either way,
+     callback will be invoked if event’s `eventPhase` attribute value
+     is `AT_TARGET`."
+    shared formal void addEventListener(String type, EventListener? callback,
+        Boolean capture = false);
+
+    "Remove the event listener in target’s list of event listeners with the
+     same [[type]], [[callback]], and [[capture]]."
+    shared formal void removeEventListener(String type, EventListener? callback,
+        Boolean capture = false);
+    
+    "Dispatches a synthetic event [[event]] to target and returns `true` if
+     either event’s cancelable attribute value is `false` or its
+     `preventDefault()` method was not invoked, and `false` otherwise."
+    shared formal Boolean dispatchEvent(Event event);
+}
+
+"An event listener can be used to observe a specific event."
+shared dynamic EventListener {
+    shared formal void handleEvent(Event event);
+}
+
+shared alias EventHandler => Anything(Event);
+
+"An event allows for signaling that something has occurred, e.g. that an image
+ has completed downloading.
+ 
+ See [https://dom.spec.whatwg.org/#event](https://dom.spec.whatwg.org/#event)"
+shared dynamic Event {
+    "Returns the type of event, e.g. `\"click\"`, `\"hashchange\"`, or `\"submit\"`."
+    shared formal String type;
+    
+    "Returns the object to which `event` is dispatched."
+    shared formal EventTarget? target;
+    shared formal EventTarget? currentTarget;
+    
+    shared formal Integer \iNONE;
+    shared formal Integer \iCAPTURING_PHASE;
+    shared formal Integer \iAT_TARGET;
+    shared formal Integer \iBUBBLING_PHASE;
+    shared formal Integer eventPhase;
+    
+    shared formal void stopPropagation();
+    shared formal void stopImmediatePropagation();
+    
+    shared formal Boolean bubbles;
+    shared formal Boolean cancelable;
+    shared formal void preventDefault();
+    shared formal Boolean defaultPrevented;
+    
+    shared formal Boolean isTrusted;
+    shared formal DOMTimeStamp timeStamp;
+    
+    shared formal void initEvent(String type, Boolean bubbles, Boolean cancelable);
+}
+
+shared Event newEvent(String type, EventInit? eventInitDict = null)
+    => newEventInternal(type, eventInitDict);
+
+shared class EventInit(bubbles = false, cancelable = false) {
+    shared Boolean bubbles;
+    shared Boolean cancelable;
+}
+
+shared alias DOMTimeStamp => Integer;
+
+shared dynamic GlobalEventHandlers {
+           shared formal EventHandler? onabort;
+           shared formal EventHandler? onblur;
+           shared formal EventHandler? oncancel;
+           shared formal EventHandler? oncanplay;
+           shared formal EventHandler? oncanplaythrough;
+           shared formal EventHandler? onchange;
+           shared formal EventHandler? onclick;
+           shared formal EventHandler? oncuechange;
+           shared formal EventHandler? ondblclick;
+           shared formal EventHandler? ondurationchange;
+           shared formal EventHandler? onemptied;
+           shared formal EventHandler? onended;
+           shared formal OnErrorEventHandler? onerror;
+           shared formal EventHandler? onfocus;
+           shared formal EventHandler? oninput;
+           shared formal EventHandler? oninvalid;
+           shared formal EventHandler? onkeydown;
+           shared formal EventHandler? onkeypress;
+           shared formal EventHandler? onkeyup;
+           shared formal EventHandler? onload;
+           shared formal EventHandler? onloadeddata;
+           shared formal EventHandler? onloadedmetadata;
+           shared formal EventHandler? onloadstart;
+           shared formal EventHandler? onmousedown;
+           shared formal EventHandler? onmouseenter;
+           shared formal EventHandler? onmouseleave;
+           shared formal EventHandler? onmousemove;
+           shared formal EventHandler? onmouseout;
+           shared formal EventHandler? onmouseover;
+           shared formal EventHandler? onmouseup;
+           shared formal EventHandler? onmousewheel;
+           shared formal EventHandler? onpause;
+           shared formal EventHandler? onplay;
+           shared formal EventHandler? onplaying;
+           shared formal EventHandler? onprogress;
+           shared formal EventHandler? onratechange;
+           shared formal EventHandler? onreset;
+           shared formal EventHandler? onresize;
+           shared formal EventHandler? onscroll;
+           shared formal EventHandler? onseeked;
+           shared formal EventHandler? onseeking;
+           shared formal EventHandler? onselect;
+           shared formal EventHandler? onshow;
+           shared formal EventHandler? onstalled;
+           shared formal EventHandler? onsubmit;
+           shared formal EventHandler? onsuspend;
+           shared formal EventHandler? ontimeupdate;
+           shared formal EventHandler? ontoggle;
+           shared formal EventHandler? onvolumechange;
+           shared formal EventHandler? onwaiting;
+}
+
+shared alias OnErrorEventHandler => Anything(String|Event, String?, Integer?,
+    Integer?, Anything?);
+
+
+shared alias OnBeforeUnloadEventHandler => String?(Event);
+
+shared dynamic WindowEventHandlers {
+           shared formal EventHandler? onafterprint;
+           shared formal EventHandler? onbeforeprint;
+           shared formal OnBeforeUnloadEventHandler? onbeforeunload;
+           shared formal EventHandler? onhashchange;
+           shared formal EventHandler? onmessage;
+           shared formal EventHandler? onoffline;
+           shared formal EventHandler? ononline;
+           shared formal EventHandler? onpagehide;
+           shared formal EventHandler? onpageshow;
+           shared formal EventHandler? onpopstate;
+           shared formal EventHandler? onstorage;
+           shared formal EventHandler? onunload;
+}

--- a/source/ceylon/interop/browser/dom/html.ceylon
+++ b/source/ceylon/interop/browser/dom/html.ceylon
@@ -1,0 +1,27 @@
+shared dynamic HTMLElement satisfies Element & GlobalEventHandlers {
+    // metadata shared formals
+    shared formal variable String title;
+    shared formal variable String lang;
+    shared formal variable Boolean translate;
+    shared formal variable String dir;
+    // TODO DOMStringMap
+    shared formal dynamic dataset;
+    
+    // user interaction
+    shared formal variable Boolean hidden;
+    shared formal void click();
+    shared formal variable Integer tabIndex;
+    shared formal void focus();
+    shared formal void blur();
+    shared formal variable String accessKey;
+    shared formal variable String accessKeyLabel;
+    shared formal variable String contentEditable;
+    shared formal Boolean isContentEditable;
+    shared formal variable Boolean spellcheck;
+}
+
+shared dynamic HTMLHeadElement satisfies HTMLElement {
+}
+
+shared dynamic HTMLUnknownElement satisfies HTMLElement {
+}

--- a/source/ceylon/interop/browser/dom/nodes.ceylon
+++ b/source/ceylon/interop/browser/dom/nodes.ceylon
@@ -1,0 +1,288 @@
+import ceylon.interop.browser {
+    Location,
+    WindowProxy,
+    window
+}
+import ceylon.interop.browser.internal {
+    newTextInternal,
+    newCommentInternal
+}
+// TODO doc
+
+
+
+shared dynamic Node satisfies EventTarget {
+    shared formal Integer \iELEMENT_NODE;
+    shared formal Integer \iATTRIBUTE_NODE; // historical
+    shared formal Integer \iTEXT_NODE;
+    shared formal Integer \iCDATA_SECTION_NODE; // historical
+    shared formal Integer \iENTITY_REFERENCE_NODE; // historical
+    shared formal Integer \iENTITY_NODE; // historical
+    shared formal Integer \iPROCESSING_INSTRUCTION_NODE;
+    shared formal Integer \iCOMMENT_NODE;
+    shared formal Integer \iDOCUMENT_NODE;
+    shared formal Integer \iDOCUMENT_TYPE_NODE;
+    shared formal Integer \iDOCUMENT_FRAGMENT_NODE;
+    shared formal Integer \iNOTATION_NODE; // historical
+    shared formal Integer nodeType;
+    shared formal String nodeName;
+    
+    shared formal String? baseURI;
+    
+    shared formal Document? ownerDocument;
+    shared formal Node? parentNode;
+    shared formal Element? parentElement;
+    shared formal Boolean hasChildNodes();
+    shared formal NodeList childNodes;
+    shared formal Node? firstChild;
+    shared formal Node? lastChild;
+    shared formal Node? previousSibling;
+    shared formal Node? nextSibling;
+    
+    shared formal variable String? nodeValue;
+    shared formal variable String? textContent;
+    shared formal void normalize();
+    
+    shared formal Node cloneNode(Boolean deep = false);
+    shared formal Boolean isEqualNode(Node? node);
+    
+    shared formal Integer \iDOCUMENT_POSITION_DISCONNECTED;
+    shared formal Integer \iDOCUMENT_POSITION_PRECEDING;
+    shared formal Integer \iDOCUMENT_POSITION_FOLLOWING;
+    shared formal Integer \iDOCUMENT_POSITION_CONTAINS;
+    shared formal Integer \iDOCUMENT_POSITION_CONTAINED_BY;
+    shared formal Integer \iDOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
+    shared formal Integer compareDocumentPosition(Node other);
+    shared formal Boolean contains(Node? other);
+    
+    shared formal String? lookupPrefix(String? namespace);
+    shared formal String? lookupNamespaceURI(String? prefix);
+    shared formal Boolean isDefaultNamespace(String? namespace);
+    
+    shared formal Node insertBefore(Node node, Node? child);
+    shared formal Node appendChild(Node node);
+    shared formal Node replaceChild(Node node, Node child);
+    shared formal Node removeChild(Node child);
+}
+
+shared dynamic Document satisfies Node & GlobalEventHandlers {
+    shared formal DOMImplementation implementation;
+    shared formal String \iURL;
+    shared formal String documentURI;
+    shared formal String origin;
+    shared formal String compatMode;
+    shared formal String characterSet;
+    shared formal String contentType;
+    
+    shared formal DocumentType? doctype;
+    shared formal Element? documentElement;
+    shared formal HTMLCollection getElementsByTagName(String localName);
+    shared formal HTMLCollection getElementsByTagNameNS(String? namespace, String localName);
+    shared formal HTMLCollection getElementsByClassName(String classNames);
+    
+    shared formal Element createElement(String localName);
+    shared formal Element createElementNS(String? namespace, String qualifiedName);
+    shared formal DocumentFragment createDocumentFragment();
+    shared formal Text createTextNode(String data);
+    shared formal Comment createComment(String data);
+    shared formal ProcessingInstruction createProcessingInstruction(String target, String data);
+    
+    shared formal Node importNode(Node node, Boolean deep = false);
+    shared formal Node adoptNode(Node node);
+    
+    shared formal Event createEvent(String \iinterface);
+    
+    shared formal Range createRange();
+    
+    shared formal NodeIterator createNodeIterator(Node root, Integer whatToShow = #FFFFFFFF, NodeFilter? filter = null);
+    shared formal TreeWalker createTreeWalker(Node root, Integer whatToShow = #FFFFFFFF, NodeFilter? filter = null);
+
+    // Extensions provided by http://www.w3.org/TR/html5/dom.html#document
+
+    // resource metadata management
+    shared formal Location? location;
+    shared formal variable String domain;
+    shared formal String referrer;
+    shared formal variable String cookie;
+    shared formal String lastModified;
+    see (`interface DocumentReadyState`)
+    shared formal String readyState;
+    
+    // DOM tree accessors
+    // TODO getter object (String name);
+    shared formal variable String title;
+    shared formal variable String dir;
+    shared formal variable HTMLElement? body;
+    shared formal HTMLHeadElement? head;
+    shared formal HTMLCollection images;
+    shared formal HTMLCollection embeds;
+    shared formal HTMLCollection plugins;
+    shared formal HTMLCollection links;
+    shared formal HTMLCollection forms;
+    shared formal HTMLCollection scripts;
+    shared formal NodeList getElementsByName(String elementName);
+    
+    // dynamic markup insertion
+    see (`function openDocument`)
+    see (`function openWindow`)
+    shared formal Document|WindowProxy open(String typeOrUrl = "text/html",
+        String replaceOrName = "", String features = "", Boolean replace = false);
+    
+    shared formal void close();
+    // TODO should be String* but it displays [Object object]
+    shared formal void write(String text);
+    // TODO should be String* but it displays [Object object]
+    shared formal void writeln(String text);
+    
+    // user interaction
+    shared formal WindowProxy? defaultView;
+    shared formal Element? activeElement;
+    shared formal Boolean hasFocus();
+    shared formal variable String designMode;
+    shared formal Boolean execCommand(String commandId, Boolean showUI = false, String val = "");
+    shared formal Boolean queryCommandEnabled(String commandId);
+    shared formal Boolean queryCommandIndeterm(String commandId);
+    shared formal Boolean queryCommandState(String commandId);
+    shared formal Boolean queryCommandSupported(String commandId);
+    shared formal String queryCommandValue(String commandId);
+    
+    // special event handler IDL attributes that only apply to Document objects
+    shared formal EventHandler onreadystatechange;
+}
+
+shared interface DocumentReadyState {
+    shared String loading => "loading";
+    shared String interactive => "interactive";
+    shared String complete => "complete";
+}
+
+shared Document document => window.document;
+
+
+// to disambiguate document.open
+shared Document openDocument(String type = "text/html", String replace = "") {
+    assert (is Document doc = document.open(type, replace));
+    return doc;
+}
+
+// to disambiguate document.open
+shared WindowProxy openWindow(String url, String name, String features,
+    Boolean replace = false) {
+    
+    assert (is WindowProxy doc = document.open(url, name, features, replace));
+    return doc;
+}
+
+shared dynamic DOMImplementation {
+    shared formal DocumentType createDocumentType(String qualifiedName, String publicId, String systemId);
+    shared formal XMLDocument createDocument(String? namespace, String? qualifiedName, DocumentType? doctype = null);
+    shared formal Document createHTMLDocument(String title);
+    
+    shared formal Boolean hasFeature(); // useless; always returns true   
+}
+
+shared dynamic DocumentType satisfies Node {
+    shared formal String name;
+    shared formal String publicId;
+    shared formal String systemId;
+}
+
+shared dynamic XMLDocument satisfies Document {
+    
+}
+
+shared dynamic DocumentFragment satisfies Node {
+    
+}
+
+shared dynamic CharacterData satisfies Node {
+    shared formal variable String data;
+    shared formal Integer length;
+    shared formal String substringData(Integer offset, Integer count);
+    shared formal void appendData(String data);
+    shared formal void insertData(Integer offset, String data);
+    shared formal void deleteData(Integer offset, Integer count);
+    shared formal void replaceData(Integer offset, Integer count, String data);  
+}
+
+shared dynamic Text satisfies CharacterData {
+    shared formal Text splitText(Integer offset);
+    shared formal String wholeText;
+}
+
+shared Text newText(String text = "") => newTextInternal(text);
+
+shared dynamic Comment satisfies CharacterData {
+}
+
+shared Comment newComment(String data = "") => newCommentInternal(data);
+
+shared dynamic ProcessingInstruction satisfies CharacterData {
+    shared formal String target;
+}
+
+shared dynamic Element satisfies Node {
+    shared formal String? namespaceURI;
+    shared formal String? prefix;
+    shared formal String localName;
+    shared formal String tagName;
+    
+    shared formal variable String id;
+    shared formal variable String className;
+    shared formal DOMTokenList classList;
+    
+    shared formal NamedNodeMap attributes;
+    shared formal String? getAttribute(String name);
+    shared formal String? getAttributeNS(String? namespace, String localName);
+    shared formal void setAttribute(String name, String val);
+    shared formal void setAttributeNS(String? namespace, String name, String val);
+    shared formal void removeAttribute(String name);
+    shared formal void removeAttributeNS(String? namespace, String localName);
+    shared formal Boolean hasAttribute(String name);
+    shared formal Boolean hasAttributeNS(String? namespace, String localName);
+    
+    
+    shared formal HTMLCollection getElementsByTagName(String localName);
+    shared formal HTMLCollection getElementsByTagNameNS(String? namespace, String localName);
+    shared formal HTMLCollection getElementsByClassName(String classNames);
+    
+    // defined in https://w3c.github.io/DOM-Parsing/#extensions-to-the-element-interface
+    shared formal variable String innerHTML;
+    shared formal variable String outerHTML;
+    shared formal void insertAdjacentHTML (String position, String text);
+}
+
+shared dynamic Attr {
+  shared formal String? namespaceURI;
+  shared formal String? prefix;
+  shared formal String localName;
+  shared formal String name;
+  shared formal variable String \ivalue;
+
+  shared formal Boolean specified; // useless; always returns true
+}
+
+shared dynamic NamedNodeMap {
+    shared formal Node getNamedItem(String name);
+    shared formal Node setNamedItem(Node arg);
+    shared formal Node removeNamedItem(String name);
+    shared formal Node item(Integer index);
+    shared formal Integer length;
+    
+    // Introduced in DOM Level 2:
+    shared formal Node getNamedItemNS(String namespaceURI, String localName);
+    shared formal Node setNamedItemNS(Node arg);
+    shared formal Node removeNamedItemNS(String namespaceURI, String localName);
+}
+
+shared dynamic NodeList {
+    shared formal Node? item(Integer index);
+    shared formal Integer length;
+    // TODO iterable<Node>;
+}
+
+shared dynamic HTMLCollection {
+    shared formal Integer length;
+    shared formal Element? item(Integer index);
+    shared formal Element? namedItem(String name);
+}

--- a/source/ceylon/interop/browser/dom/package.ceylon
+++ b/source/ceylon/interop/browser/dom/package.ceylon
@@ -1,0 +1,1 @@
+shared package ceylon.interop.browser.dom;

--- a/source/ceylon/interop/browser/dom/ranges.ceylon
+++ b/source/ceylon/interop/browser/dom/ranges.ceylon
@@ -1,0 +1,49 @@
+import ceylon.interop.browser.internal {
+    newRangeInternal
+}
+// TODO doc
+
+
+shared dynamic Range {
+    shared formal Node startContainer;
+    shared formal Integer startOffset;
+    shared formal Node endContainer;
+    shared formal Integer endOffset;
+    shared formal Boolean collapsed;
+    shared formal Node commonAncestorContainer;
+    
+    shared formal void setStart(Node node, Integer offset);
+    shared formal void setEnd(Node node, Integer offset);
+    shared formal void setStartBefore(Node node);
+    shared formal void setStartAfter(Node node);
+    shared formal void setEndBefore(Node node);
+    shared formal void setEndAfter(Node node);
+    shared formal void collapse(Boolean toStart = false);
+    shared formal void selectNode(Node node);
+    shared formal void selectNodeContents(Node node);
+    
+    shared formal Integer \iSTART_TO_START;
+    shared formal Integer \iSTART_TO_END;
+    shared formal Integer \iEND_TO_END;
+    shared formal Integer \iEND_TO_START;
+    shared formal Integer compareBoundaryPoints(Integer how, Range sourceRange);
+    
+    shared formal void deleteContents();
+    shared formal DocumentFragment extractContents();
+    shared formal DocumentFragment cloneContents();
+    shared formal void insertNode(Node node);
+    shared formal void surroundContents(Node newParent);
+    
+    shared formal Range cloneRange();
+    shared formal void detach();
+    
+    shared formal Boolean isPointInRange(Node node, Integer offset);
+    shared formal Integer comparePoint(Node node, Integer offset);
+    
+    shared formal Boolean intersectsNode(Node node);
+    
+    // extensions from https://w3c.github.io/DOM-Parsing/#extensions-to-the-range-interface
+    shared formal DocumentFragment createContextualFragment (String fragment);
+}
+
+shared Range newRange() => newRangeInternal();

--- a/source/ceylon/interop/browser/dom/sets.ceylon
+++ b/source/ceylon/interop/browser/dom/sets.ceylon
@@ -1,0 +1,13 @@
+shared dynamic DOMTokenList {
+    shared formal Integer length;
+    shared formal String? item(Integer index);
+    shared formal Boolean contains(String token);
+    // TODO should be String*
+    shared formal void add(String tokens);
+    // TODO should be String*
+    shared formal void remove(String tokens);
+    shared formal Boolean toggle(String token, Boolean force);
+
+    // TODO stringifier;
+    // TODO iterable<DOMString>;
+}

--- a/source/ceylon/interop/browser/dom/traversal.ceylon
+++ b/source/ceylon/interop/browser/dom/traversal.ceylon
@@ -1,0 +1,55 @@
+// TODO doc
+
+
+
+shared dynamic NodeIterator {
+    shared formal Node root;
+    shared formal Node referenceNode;
+    shared formal Boolean pointerBeforeReferenceNode;
+    shared formal Integer whatToShow;
+    shared formal NodeFilter? filter;
+    
+    shared formal Node? nextNode();
+    shared formal Node? previousNode();
+    
+    shared formal void detach();
+}
+
+shared dynamic NodeFilter {
+    // Constants for acceptNode()
+    shared formal Integer \iFILTER_ACCEPT;
+    shared formal Integer \iFILTER_REJECT;
+    shared formal Integer \iFILTER_SKIP;
+    
+    // Constants for whatToShow
+    shared formal Integer \iSHOW_ALL;
+    shared formal Integer \iSHOW_ELEMENT;
+    shared formal Integer \iSHOW_ATTRIBUTE; // historical
+    shared formal Integer \iSHOW_TEXT;
+    shared formal Integer \iSHOW_CDATA_SECTION; // historical
+    shared formal Integer \iSHOW_ENTITY_REFERENCE; // historical
+    shared formal Integer \iSHOW_ENTITY; // historical
+    shared formal Integer \iSHOW_PROCESSING_INSTRUCTION;
+    shared formal Integer \iSHOW_COMMENT;
+    shared formal Integer \iSHOW_DOCUMENT;
+    shared formal Integer \iSHOW_DOCUMENT_TYPE;
+    shared formal Integer \iSHOW_DOCUMENT_FRAGMENT;
+    shared formal Integer \iSHOW_NOTATION; // historical
+    
+    shared formal Integer acceptNode(Node node);
+}
+
+shared dynamic TreeWalker {
+    shared formal Node root;
+    shared formal Integer whatToShow;
+    shared formal NodeFilter? filter;
+    shared formal variable Node currentNode;
+    
+    shared formal Node? parentNode();
+    shared formal Node? firstChild();
+    shared formal Node? lastChild();
+    shared formal Node? previousSibling();
+    shared formal Node? nextSibling();
+    shared formal Node? previousNode();
+    shared formal Node? nextNode();
+}

--- a/source/ceylon/interop/browser/internal/nativeObjects.ceylon
+++ b/source/ceylon/interop/browser/internal/nativeObjects.ceylon
@@ -1,0 +1,46 @@
+import ceylon.interop.browser {
+    IXMLHttpRequest=XMLHttpRequest
+}
+import ceylon.interop.browser.dom {
+    IEvent=Event,
+    EventInit,
+    Text,
+    Range,
+    Comment
+}
+
+shared IEvent newEventInternal(String type, EventInit? eventInitDict) {
+    dynamic {
+        obj = eval("Event");
+        return \Iobj(type, eventInitDict);
+    }
+}
+
+shared IXMLHttpRequest newXMLHttpRequestInternal() {
+    dynamic {
+        // otherwise it seems our interface is used instead :(
+        obj = eval("XMLHttpRequest");
+        return \Iobj();
+    }
+}
+
+shared Text newTextInternal(String text) {
+    dynamic {
+        obj = eval("Text");
+        return \Iobj(text);
+    }
+}
+
+shared Range newRangeInternal() {
+    dynamic {
+        obj = eval("Range");
+        return \Iobj();
+    }
+}
+
+shared Comment newCommentInternal(String data) {
+    dynamic {
+        obj = eval("Comment");
+        return \Iobj(data);
+    }
+}

--- a/source/ceylon/interop/browser/internal/package.ceylon
+++ b/source/ceylon/interop/browser/internal/package.ceylon
@@ -1,0 +1,2 @@
+suppressWarnings("ceylonNamespace")
+package ceylon.interop.browser.internal;

--- a/source/ceylon/interop/browser/module.ceylon
+++ b/source/ceylon/interop/browser/module.ceylon
@@ -1,0 +1,5 @@
+"Provides dynamic interfaces for APIs exposed by web browsers,
+ such as DOM nodes, DOMS events, DOM traversal or XMLHttpRequest."
+native("js")
+suppressWarnings("ceylonNamespace")
+module ceylon.interop.browser "1.2.1" {}

--- a/source/ceylon/interop/browser/package.ceylon
+++ b/source/ceylon/interop/browser/package.ceylon
@@ -1,0 +1,2 @@
+suppressWarnings("ceylonNamespace")
+shared package ceylon.interop.browser;


### PR DESCRIPTION
This PR adds a new module named `ceylon.interop.browser` which adds lots of dynamic interfaces to access browser APIs in Ceylon:

* XMLHttpRequest
* DOM nodes
* DOM events
* DOM traversal
* DOM ranges

Example of code using this module:

```ceylon
shared void run() {
    
    if (exists body = document.getElementsByTagName("body").item(0)) {
        value div = document.createElement("div");
        body.appendChild(div);
        
        value hello = document.createElement("p");
        hello.innerHTML = "Hello world!";
        div.appendChild(hello);
        
        value progress = document.createElement("p");
        div.appendChild(progress);
        
        value req = newXMLHttpRequest();
        req.open("GET", "/index.html", false);
        req.onreadystatechange = (Event evt) {
            progress.appendChild(newText("New state: " + req.readyState.string));
        };
        req.send();
        
        if (req.readyState == req.\iDONE) {
            progress.appendChild(newText(", received " + req.responseText.spanTo(20) + "..."));
        }
    }
}
```