### PR TITLE
server-side: read binary and extract form parameters only (omitting query parameters)

### DIFF
--- a/source/ceylon/net/http/server/Request.ceylon
+++ b/source/ceylon/net/http/server/Request.ceylon
@@ -15,6 +15,9 @@ shared interface Request {
      [[forceFormParsing]] is false (default) and parameter 
      with the same name exists in a query string, posted 
      data is not parsed."
+    deprecated("Not specifying if the parameter's value should come from the query part
+                in the URL or from the request body is discouraged at this level.
+                Please use either [[queryParameter]] or [[formParameter]].")
     shared formal String? parameter(String name, 
         Boolean forceFormParsing = false);
     
@@ -23,6 +26,9 @@ shared interface Request {
      with the same name exists in a query string, posted 
      data is not parsed. It is returned, only if it is 
      already parsed."
+    deprecated("Not specifying if the parameter's values should come from the query part
+                in the URL or from the request body is discouraged at this level.
+                Please use either [[queryParameters]] or [[formParameters]].")
     shared formal String[] parameters(String name, 
         Boolean forceFormParsing = false);
 
@@ -36,11 +42,17 @@ shared interface Request {
     "Returns all headers with given name."
     shared formal String[] headers(String name);
 
+	"Returns a single query parameter with the given name (from the query part of the request URL)."
+    shared formal String? queryParameter(String name);
+
+	"Returns all single query parameter with the given name (from the query part of the request URL)."
+    shared formal String[] queryParameters(String name);
+
     "Returns a single form parameter with the given name from the request body. Content-Type must be application/x-www-form-urlencoded."
     shared formal String? formParameter(String name);
 
     "Returns all form parameters with the given name from the request body. Content-Type must be application/x-www-form-urlencoded."
-    shared formal String[]? formParameters(String name);
+    shared formal String[] formParameters(String name);
 
     "Get the HTTP request method.
      {OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT}"

--- a/source/ceylon/net/http/server/Request.ceylon
+++ b/source/ceylon/net/http/server/Request.ceylon
@@ -5,34 +5,34 @@ import ceylon.net.http {
     Method
 }
 
-"Defines an object to provide client request information
+"Defines an object to provide client request information 
  to a web endpoint."
 by("Matej Lazar")
 shared interface Request {
-
-    "Returns a single parameters with given name. If there
-     are more, the first one is returned. If
-     [[forceFormParsing]] is false (default) and parameter
-     with the same name exists in a query string, posted
+    
+    "Returns a single parameters with given name. If there 
+     are more, the first one is returned. If 
+     [[forceFormParsing]] is false (default) and parameter 
+     with the same name exists in a query string, posted 
      data is not parsed."
-    shared formal String? parameter(String name,
+    shared formal String? parameter(String name, 
         Boolean forceFormParsing = false);
-
-    "Returns all parameters with given name. If
-     [[forceFormParsing]] is false (default) and parameter
-     with the same name exists in a query string, posted
-     data is not parsed. It is returned, only if it is
+    
+    "Returns all parameters with given name. If 
+     [[forceFormParsing]] is false (default) and parameter 
+     with the same name exists in a query string, posted 
+     data is not parsed. It is returned, only if it is 
      already parsed."
-    shared formal String[] parameters(String name,
+    shared formal String[] parameters(String name, 
         Boolean forceFormParsing = false);
 
     shared formal UploadedFile? file(String name);
 
     shared formal UploadedFile[] files(String name);
-
+    
     "Returns a single header with given name."
     shared formal String? header(String name);
-
+    
     "Returns all headers with given name."
     shared formal String[] headers(String name);
 
@@ -45,18 +45,18 @@ shared interface Request {
     "Get the HTTP request method.
      {OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT}"
     shared formal Method method;
-
+    
     "Get the request URI scheme. {http, https}"
     shared formal String scheme;
-
+    
     "Gets the request URI, including hostname, protocol
      etc if specified by the client."
     shared formal String uri;
-
+    
     "Get the request URI path.  This is the whole original
      request path."
     shared formal String path;
-
+    
     "Read the contents of the request as text."
     shared formal String read();
 
@@ -66,25 +66,25 @@ shared interface Request {
     "Return path relative to endpoint mapping path.
      Relative path is a substring of path without
      [[startsWith]] mappings.
-
-     Note that endpoints mapped with [[And]] and [[endsWith]]
-     will return complete path instead of relative. See
+    
+     Note that endpoints mapped with [[And]] and [[endsWith]] 
+     will return complete path instead of relative. See 
      [[Matcher.relativePath]] for details."
     shared formal String relativePath;
-
+    
     shared formal String queryString;
-
+    
     "Get the source address of the HTTP request."
     shared formal SocketAddress sourceAddress;
-
+    
     "Get the destination address of the HTTP request."
     shared formal SocketAddress destinationAddress;
-
+    
     "Returns request content type, read from header."
     shared formal String? contentType;
-
-    "Returns users http session. If session doesn't exists,
+    
+    "Returns users http session. If session doesn't exists, 
      a new is created."
     shared formal Session session;
-
+    
 }

--- a/source/ceylon/net/http/server/Request.ceylon
+++ b/source/ceylon/net/http/server/Request.ceylon
@@ -5,77 +5,86 @@ import ceylon.net.http {
     Method
 }
 
-"Defines an object to provide client request information 
+"Defines an object to provide client request information
  to a web endpoint."
 by("Matej Lazar")
 shared interface Request {
-    
-    "Returns a single parameters with given name. If there 
-     are more, the first one is returned. If 
-     [[forceFormParsing]] is false (default) and parameter 
-     with the same name exists in a query string, posted 
+
+    "Returns a single parameters with given name. If there
+     are more, the first one is returned. If
+     [[forceFormParsing]] is false (default) and parameter
+     with the same name exists in a query string, posted
      data is not parsed."
-    shared formal String? parameter(String name, 
+    shared formal String? parameter(String name,
         Boolean forceFormParsing = false);
-    
-    "Returns all parameters with given name. If 
-     [[forceFormParsing]] is false (default) and parameter 
-     with the same name exists in a query string, posted 
-     data is not parsed. It is returned, only if it is 
+
+    "Returns all parameters with given name. If
+     [[forceFormParsing]] is false (default) and parameter
+     with the same name exists in a query string, posted
+     data is not parsed. It is returned, only if it is
      already parsed."
-    shared formal String[] parameters(String name, 
+    shared formal String[] parameters(String name,
         Boolean forceFormParsing = false);
 
     shared formal UploadedFile? file(String name);
 
     shared formal UploadedFile[] files(String name);
-    
+
     "Returns a single header with given name."
     shared formal String? header(String name);
-    
+
     "Returns all headers with given name."
     shared formal String[] headers(String name);
-    
-    "Get the HTTP request method. 
+
+    "Returns a single form parameter with the given name from the request body. Content-Type must be application/x-www-form-urlencoded."
+    shared formal String? formParameter(String name);
+
+    "Returns all form parameters with the given name from the request body. Content-Type must be application/x-www-form-urlencoded."
+    shared formal String[]? formParameters(String name);
+
+    "Get the HTTP request method.
      {OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT}"
     shared formal Method method;
-    
+
     "Get the request URI scheme. {http, https}"
     shared formal String scheme;
-    
-    "Gets the request URI, including hostname, protocol 
+
+    "Gets the request URI, including hostname, protocol
      etc if specified by the client."
     shared formal String uri;
-    
-    "Get the request URI path.  This is the whole original 
+
+    "Get the request URI path.  This is the whole original
      request path."
     shared formal String path;
-    
+
     "Read the contents of the request as text."
     shared formal String read();
 
+    "Read the contents of the request as binary byte array."
+    shared formal Byte[] readBinary();
+
     "Return path relative to endpoint mapping path.
-     Relative path is a substring of path without 
+     Relative path is a substring of path without
      [[startsWith]] mappings.
-     
-     Note that endpoints mapped with [[And]] and [[endsWith]] 
-     will return complete path instead of relative. See 
+
+     Note that endpoints mapped with [[And]] and [[endsWith]]
+     will return complete path instead of relative. See
      [[Matcher.relativePath]] for details."
     shared formal String relativePath;
-    
+
     shared formal String queryString;
-    
+
     "Get the source address of the HTTP request."
     shared formal SocketAddress sourceAddress;
-    
+
     "Get the destination address of the HTTP request."
     shared formal SocketAddress destinationAddress;
-    
+
     "Returns request content type, read from header."
     shared formal String? contentType;
-    
-    "Returns users http session. If session doesn't exists, 
+
+    "Returns users http session. If session doesn't exists,
      a new is created."
     shared formal Session session;
-    
+
 }

--- a/source/ceylon/net/http/server/internal/RequestImpl.ceylon
+++ b/source/ceylon/net/http/server/internal/RequestImpl.ceylon
@@ -62,7 +62,7 @@ import java.lang {
 }
 
 by("Matej Lazar")
-class RequestImpl(HttpServerExchange exchange,
+class RequestImpl(HttpServerExchange exchange, 
     FormParserFactory formParserFactory, endpoint, path, method)
         satisfies Request {
 
@@ -72,19 +72,19 @@ class RequestImpl(HttpServerExchange exchange,
 
     shared actual Method method;
 
-    String? getHeader(String name)
+    String? getHeader(String name) 
             => exchange.requestHeaders.getFirst(HttpString(name));
 
     contentType => getHeader(headerConntentType.string);
 
     header(String name) => getHeader(name);
-
+    
     shared actual String read() {
         exchange.startBlocking();
         value inputStream = exchange.inputStream;
         try {
-            value inputStreamReader =
-                    InputStreamReader(inputStream,
+            value inputStreamReader = 
+                    InputStreamReader(inputStream, 
                         exchange.requestCharset);
             value reader = BufferedReader(inputStreamReader);
             value builder = StringBuilder();
@@ -135,44 +135,44 @@ class RequestImpl(HttpServerExchange exchange,
                 exchange.startBlocking();
             }
         }
-
+        
         value formDataBuilder = FormDataBuilder();
-
+        
         value utFormData = getUtFormData();
-
+        
         value formDataIt = utFormData.iterator();
         while (formDataIt.hasNext()) {
-            JString key = formDataIt.next();
+            JString key = formDataIt.next(); 
             value valuesIt = utFormData.get(key.string).iterator();
             while (valuesIt.hasNext()) {
                 value parameterValue = valuesIt.next();
                 if (paramIsFile(parameterValue)) {
-                    value uploadedFile = UploadedFile {
+                    value uploadedFile = UploadedFile { 
                         file = parsePath(paramFile(parameterValue).absolutePath);
                         fileName = parameterValue.fileName;
                     };
                     formDataBuilder.addFile(key.string, uploadedFile);
                 } else {
-                    formDataBuilder.addParameter(key.string,
+                    formDataBuilder.addParameter(key.string, 
                         paramValue(parameterValue));
                 }
             }
         }
         return formDataBuilder.build();
     }
-
+    
     Map<String, String[]> readQueryParameters() {
         value queryParameters = HashMap<String, String[]>();
         value utQueryParameters = exchange.queryParameters;
-
+        
         value it = utQueryParameters.keySet().iterator();
         while (it.hasNext()) {
             JString key = it.next();
-            value values = utQueryParameters.get(key);
+            value values = utQueryParameters.get(key); 
             value valuesIt = values.iterator();
             value sequenceBuilder = ArrayList<String>();
             while (valuesIt.hasNext()) {
-                value paramValue = valuesIt.next();
+                value paramValue = valuesIt.next(); 
                 sequenceBuilder.add(paramValue.string);
             }
             queryParameters.put(key.string, sequenceBuilder.sequence());
@@ -181,11 +181,11 @@ class RequestImpl(HttpServerExchange exchange,
     }
 
     variable Map<String, String[]>? lazyQueryParameters = null;
-    value queryParameters => lazyQueryParameters
+    value queryParameters => lazyQueryParameters 
             else (lazyQueryParameters = readQueryParameters());
 
     variable FormData? lazyFormData = null;
-    value formData => lazyFormData
+    value formData => lazyFormData 
             else (lazyFormData = buildFormData()) ;
 
     shared actual String[]? formParameters(String name) {
@@ -204,17 +204,17 @@ class RequestImpl(HttpServerExchange exchange,
     shared actual String[] headers(String name) {
         value headers = exchange.requestHeaders.get(HttpString(name));
         value sequenceBuilder = ArrayList<String>();
-
+        
         value it = headers.iterator();
         while (it.hasNext()) {
             value header = it.next();
             sequenceBuilder.add(header.string);
         }
-
+        
         return sequenceBuilder.sequence();
     }
 
-    shared actual String[] parameters(String name,
+    shared actual String[] parameters(String name, 
             Boolean forceFormParse) {
 
         value mergedParams = ArrayList<String>();
@@ -234,7 +234,7 @@ class RequestImpl(HttpServerExchange exchange,
         return mergedParams.sequence();
     }
 
-    shared actual String? parameter(String name,
+    shared actual String? parameter(String name, 
             Boolean forceFormParsing) {
         value params = parameters(name);
         if (nonempty params) {
@@ -277,15 +277,15 @@ class RequestImpl(HttpServerExchange exchange,
         value address = exchange.destinationAddress;
         return SocketAddress(address.hostString, address.port);
     }
-
+    
     shared actual Session session {
-        SessionManager sessionManager
+        SessionManager sessionManager 
                 = exchange.getAttachment(smAttachmentKey);
 
         //TODO configurable session cookie
         value sessionCookieConfig = SessionCookieConfig();
 
-        variable UtSession? utSession =
+        variable UtSession? utSession = 
                 sessionManager.getSession(exchange, sessionCookieConfig);
 
         if (!utSession exists) {
@@ -299,7 +299,7 @@ class RequestImpl(HttpServerExchange exchange,
         }
     }
 
-    Boolean initialized(Object? obj) {
+    Boolean initialized(Object? obj) { 
         if (exists obj) {
             return true;
         }

--- a/test-source/test/ceylon/net/server.ceylon
+++ b/test-source/test/ceylon/net/server.ceylon
@@ -3,9 +3,9 @@ import ceylon.io { OpenFile, newOpenFile }
 import ceylon.io.charset { stringToByteProducer, utf8 }
 import ceylon.net.uri { parse, Parameter }
 import ceylon.net.http.client { ClientRequest=Request }
-import ceylon.net.http.server { Status,
-                                  started, AsynchronousEndpoint,
-                                  Endpoint, Response, Request,
+import ceylon.net.http.server { Status, 
+                                  started, AsynchronousEndpoint, 
+                                  Endpoint, Response, Request, 
                                   startsWith, endsWith, Options, stopped, newServer }
 import ceylon.net.http.server.endpoints { serveStaticFile }
 import ceylon.test { assertEquals, assertTrue, test }
@@ -53,7 +53,7 @@ variable String asyncServiceStatus = "";
 test void testServer() {
 
     function name(Request request) => request.parameter("name") else "world";
-
+    
     void serviceImpl(Request request, Response response) {
         response.addHeader(contentType { contentType = "text/html"; charset = utf8; });
         response.writeString("Hello ``name(request)``!");
@@ -61,7 +61,7 @@ test void testServer() {
 
     //add fileEndpoint
     value testFile = creteTestFile();
-
+    
     String fileMapper(Request request) {
         return testFile.string;
     }
@@ -169,20 +169,20 @@ test void testServer() {
         AsynchronousEndpoint {
             service => serveStaticFile(".");
             path = startsWith("/lazy")
-                    .or(startsWith("/blob"))
+                    .or(startsWith("/blob")) 
                     .or(endsWith(".txt"));
         },
         AsynchronousEndpoint {
             service => serveStaticFile("", fileMapper);
             path = startsWith("/filemapper");
         },
-        Endpoint {
-            path = startsWith("/serializer");
+        Endpoint { 
+            path = startsWith("/serializer"); 
             void service(Request request, Response response) {
                 NodeSerializer(response.writeString).serialize(
                     Html {
-                        doctype = html5;
-                        Head { title = "Hello"; };
+                        doctype = html5; 
+                        Head { title = "Hello"; }; 
                         Body {
                             P("Hello!")
                         };
@@ -190,10 +190,10 @@ test void testServer() {
                 );
             }
         },
-        AsynchronousEndpoint {
-
-            path = startsWith("/async");
-
+        AsynchronousEndpoint { 
+            
+            path = startsWith("/async"); 
+            
             void service (Request request, Response response, void complete()) {
                 value startTime = system.milliseconds;
                 String source = request.sourceAddress.address;
@@ -206,23 +206,23 @@ test void testServer() {
                 }
                 String responseString = sb.string;
                 response.addHeader(contentLength(responseString.size.string));
-
-                response.writeStringAsynchronous {
+                
+                response.writeStringAsynchronous { 
                     string => responseString;
                     void onCompletion () {
                         asyncServiceStatus = "completing";
                         //TODO log
                         print("Completed in ``system.milliseconds - startTime``ms.");
                         complete();
-                    }
+                    } 
                 };
                 //TODO log
                 print("Returned in ``system.milliseconds - startTime``ms.");
                 asyncServiceStatus = "returning";
             }
         },
-        Endpoint {
-            path = startsWith("/multipartPost");
+        Endpoint { 
+            path = startsWith("/multipartPost"); 
             service = (Request request, Response response) {
                 variable String responseString = "";
                 if(exists uploadedFile = request.file("file1")) {
@@ -232,7 +232,7 @@ test void testServer() {
                         responseString += utf8.decode(buffer);
                     });
                 }
-
+                
                 if(exists uploadedFile = request.file("file2")) {
                     print("Server got file: ``uploadedFile.file``");
                     value openfile = newOpenFile(uploadedFile.file.resource);
@@ -240,18 +240,18 @@ test void testServer() {
                         responseString += utf8.decode(buffer);
                     });
                 }
-
+                
                 responseString += Parameter(param1.name, request.parameter(param1.name)).humanRepresentation;
                 responseString += "\n";
                 responseString += Parameter(param2.name, request.parameter(param2.name)).humanRepresentation;
                 responseString += "\n";
-
+                
                 response.addHeader(contentType("text/html", utf8));
                 response.writeString(responseString);
                 return null;
-            };
+            }; 
             acceptMethod = {post};
-        }
+        }        
     };
 
 
@@ -262,19 +262,19 @@ test void testServer() {
             try {
                 if (true) {
                 headerTest();
-
+                
                 executeEchoTest("Ceylon");
-
+                
                 fileMapperTest();
-
+                
                 concurentFileRequests(numberOfUsers);
-
+                
                 acceptMethodTest();
-
+                
                 acceptMethodTestSameUrl();
-
+                
                 methodTest();
-
+                
                 parametersTest("čšž", "ČŠŽ ĐŽ");
 
                 formParametersTest("aKey", "aValue", "val2");
@@ -287,14 +287,14 @@ test void testServer() {
 
                 //TODO enable session test when client suports it
                 //sessionTest();
-
+                
                 testSerializer();
-
+                
                 //TODO enable async "streaming" test
                 //testAsyncStream();
-                }
+               }
                 testMultipartPost();
-
+                
             } finally {
                 cleanUpFile();
                 server.stop();
@@ -320,7 +320,7 @@ test void testServer() {
 void executeEchoTest(String name) {
     //TODO log debug
     print("Making request to Ceylon server...");
-
+    
     value expecting = "Hello ``name``!";
 
     value request = ClientRequest(parse("http://localhost:8080/echo?name=" + name));
@@ -335,16 +335,16 @@ void executeEchoTest(String name) {
 
 void headerTest() {
     String contentType = "application/x-www-form-urlencoded";
-
+    
     value request = ClientRequest(parse("http://localhost:8080/headerTest"));
     request.setHeader("Content-Type", contentType);
-
+    
     value response = request.execute();
 
     value echoMsg = response.contents;
     //TODO log debug
     print("Received contents: ``echoMsg``");
-
+    
     value contentTypeHeader = response.getSingleHeader("Content-Type");
     response.close();
 
@@ -379,23 +379,23 @@ void fileMapperTest() {
 
 void concurentFileRequests(Integer concurentRequests) {
     variable Integer requestNumber = 0;
-
+    
     object user satisfies Runnable {
         shared actual void run() {
             executeTestStaticFile(requestsPerUser);
         }
     }
-
+    
     value users = LinkedList<Thread>();
 
-    print ("Running ``concurentRequests `` concurent requests.");
+    print ("Running ``concurentRequests `` concurrent requests.");    
     while(requestNumber < concurentRequests) {
         value userThread = Thread(user);
         users.add(userThread);
         userThread.start();
         requestNumber++;
     }
-
+    
     //wait for users to complete requests
     for (userThread in users) {
         userThread.join();
@@ -430,7 +430,7 @@ void cleanUpFile() {
 
 test void testPathMatcher() {
     String requestPath = "/file/myfile.txt";
-
+    
     value matcherStarts = startsWith("/file");
     assertTrue(matcherStarts.matches(requestPath));
 
@@ -439,10 +439,10 @@ test void testPathMatcher() {
 
     value matcher = startsWith("/file");
     assertEquals("/myfile.txt", matcher.relativePath(requestPath));
-
+    
     value matcher2 = endsWith(".txt");
     assertEquals("/file/myfile.txt", matcher2.relativePath(requestPath));
-
+    
     value matcher3 = startsWith("/file").and(endsWith(".txt"));
     assertEquals("/file/myfile.txt", matcher3.relativePath(requestPath));
 
@@ -455,7 +455,7 @@ test void testPathMatcher() {
     assertEquals("/myfile.txt", matcher5.relativePath(requestPath));
 
     value matcher6 = (startsWith("/blob")
-            .or(startsWith("/file"))
+            .or(startsWith("/file")) 
             .and(endsWith(".txt")));
     assertEquals("/file/myfile.txt", matcher6.relativePath(requestPath));
 }
@@ -524,7 +524,7 @@ void acceptMethodTest() {
     //TODO log
     assertEquals(response1Status, 200);
 
-    //do NOT accept PUT
+    //do NOT accept PUT 
     value request2 = ClientRequest(parse("http://localhost:8080/acceptMethodTest"));
     request2.method = put;
     request2.setParameter(Parameter("foo", "valueFoo"));
@@ -671,7 +671,7 @@ void sessionTest() {
 
 void testSerializer() {
     value request = ClientRequest(parse("http://localhost:8080/serializer"), get);
-
+    
     value response = request.execute();
     value responseContent = response.contents;
     //TODO log
@@ -717,7 +717,7 @@ void testAsyncStream() {
         process.write("``read``.");
     }
     print("Read in ``system.milliseconds - startTime``ms.");
-
+    
     ByteBuffer contentBuff = newByteBuffer(content.size);
     for (b in content) {
         contentBuff.putByte(b);

--- a/test-source/test/ceylon/net/server.ceylon
+++ b/test-source/test/ceylon/net/server.ceylon
@@ -3,9 +3,9 @@ import ceylon.io { OpenFile, newOpenFile }
 import ceylon.io.charset { stringToByteProducer, utf8 }
 import ceylon.net.uri { parse, Parameter }
 import ceylon.net.http.client { ClientRequest=Request }
-import ceylon.net.http.server { Status, 
-                                  started, AsynchronousEndpoint, 
-                                  Endpoint, Response, Request, 
+import ceylon.net.http.server { Status,
+                                  started, AsynchronousEndpoint,
+                                  Endpoint, Response, Request,
                                   startsWith, endsWith, Options, stopped, newServer }
 import ceylon.net.http.server.endpoints { serveStaticFile }
 import ceylon.test { assertEquals, assertTrue, test }
@@ -23,10 +23,11 @@ import ceylon.html {
 import ceylon.html.serializer {
     NodeSerializer
 }
-import ceylon.io.buffer { newByteBuffer, ByteBuffer }
+import ceylon.io.buffer { newByteBuffer, ByteBuffer,
+    newByteBufferWithData }
 import test.ceylon.net.multipartclient {
-	MultipartRequest,
-	FilePart
+    MultipartRequest,
+    FilePart
 }
 
 by("Matej Lazar")
@@ -52,7 +53,7 @@ variable String asyncServiceStatus = "";
 test void testServer() {
 
     function name(Request request) => request.parameter("name") else "world";
-    
+
     void serviceImpl(Request request, Response response) {
         response.addHeader(contentType { contentType = "text/html"; charset = utf8; });
         response.writeString("Hello ``name(request)``!");
@@ -60,7 +61,7 @@ test void testServer() {
 
     //add fileEndpoint
     value testFile = creteTestFile();
-    
+
     String fileMapper(Request request) {
         return testFile.string;
     }
@@ -118,6 +119,28 @@ test void testServer() {
         Endpoint {
             service => void (Request request, Response response) {
                 response.addHeader(contentType("text/html", utf8));
+                response.writeString(request.formParameters("aKey")?.string else "");
+            };
+            path = startsWith("/formParamsTest");
+        },
+        Endpoint {
+            service => void (Request request, Response response) {
+                response.addHeader(contentType("text/html", utf8));
+                response.writeString(request.formParameter("aKey")?.string else "");
+            };
+            path = startsWith("/formParamTest");
+        },
+        Endpoint {
+            service => void (Request request, Response response) {
+                value data = request.readBinary();
+                value converted = data.map((Byte element) => element.unsigned);
+                response.writeString(converted.string);
+            };
+            path = startsWith("/readBinary");
+        },
+        Endpoint {
+            service => void (Request request, Response response) {
+                response.addHeader(contentType("text/html", utf8));
                 for (i in 0..10) {
                     response.writeString("foo ``i``\n");
                 }
@@ -146,20 +169,20 @@ test void testServer() {
         AsynchronousEndpoint {
             service => serveStaticFile(".");
             path = startsWith("/lazy")
-                    .or(startsWith("/blob")) 
+                    .or(startsWith("/blob"))
                     .or(endsWith(".txt"));
         },
         AsynchronousEndpoint {
             service => serveStaticFile("", fileMapper);
             path = startsWith("/filemapper");
         },
-        Endpoint { 
-            path = startsWith("/serializer"); 
+        Endpoint {
+            path = startsWith("/serializer");
             void service(Request request, Response response) {
                 NodeSerializer(response.writeString).serialize(
                     Html {
-                        doctype = html5; 
-                        Head { title = "Hello"; }; 
+                        doctype = html5;
+                        Head { title = "Hello"; };
                         Body {
                             P("Hello!")
                         };
@@ -167,10 +190,10 @@ test void testServer() {
                 );
             }
         },
-        AsynchronousEndpoint { 
-            
-            path = startsWith("/async"); 
-            
+        AsynchronousEndpoint {
+
+            path = startsWith("/async");
+
             void service (Request request, Response response, void complete()) {
                 value startTime = system.milliseconds;
                 String source = request.sourceAddress.address;
@@ -183,23 +206,23 @@ test void testServer() {
                 }
                 String responseString = sb.string;
                 response.addHeader(contentLength(responseString.size.string));
-                
-                response.writeStringAsynchronous { 
+
+                response.writeStringAsynchronous {
                     string => responseString;
                     void onCompletion () {
                         asyncServiceStatus = "completing";
                         //TODO log
                         print("Completed in ``system.milliseconds - startTime``ms.");
                         complete();
-                    } 
+                    }
                 };
                 //TODO log
                 print("Returned in ``system.milliseconds - startTime``ms.");
                 asyncServiceStatus = "returning";
             }
         },
-        Endpoint { 
-            path = startsWith("/multipartPost"); 
+        Endpoint {
+            path = startsWith("/multipartPost");
             service = (Request request, Response response) {
                 variable String responseString = "";
                 if(exists uploadedFile = request.file("file1")) {
@@ -209,7 +232,7 @@ test void testServer() {
                         responseString += utf8.decode(buffer);
                     });
                 }
-                
+
                 if(exists uploadedFile = request.file("file2")) {
                     print("Server got file: ``uploadedFile.file``");
                     value openfile = newOpenFile(uploadedFile.file.resource);
@@ -217,18 +240,18 @@ test void testServer() {
                         responseString += utf8.decode(buffer);
                     });
                 }
-                
+
                 responseString += Parameter(param1.name, request.parameter(param1.name)).humanRepresentation;
                 responseString += "\n";
                 responseString += Parameter(param2.name, request.parameter(param2.name)).humanRepresentation;
                 responseString += "\n";
-                
+
                 response.addHeader(contentType("text/html", utf8));
                 response.writeString(responseString);
                 return null;
-            }; 
+            };
             acceptMethod = {post};
-        }        
+        }
     };
 
 
@@ -237,35 +260,41 @@ test void testServer() {
     void onStartedExecuteTest(Status status) {
         if (status.equals(started)) {
             try {
-                if (false) {
+                if (true) {
                 headerTest();
-                
+
                 executeEchoTest("Ceylon");
-                
+
                 fileMapperTest();
-                
+
                 concurentFileRequests(numberOfUsers);
-                
+
                 acceptMethodTest();
-                
+
                 acceptMethodTestSameUrl();
-                
+
                 methodTest();
-                
+
                 parametersTest("čšž", "ČŠŽ ĐŽ");
-                
+
+                formParametersTest("aKey", "aValue", "val2");
+
+                formParameterTest("aKey", "aValue", "val2");
+
                 writeStringsTest();
-                
+
+                readBinaryTest(Byte(1), Byte(252), Byte(3), Byte(0), Byte(2));
+
                 //TODO enable session test when client suports it
                 //sessionTest();
-                
+
                 testSerializer();
-                
+
                 //TODO enable async "streaming" test
                 //testAsyncStream();
-            	}
+                }
                 testMultipartPost();
-                
+
             } finally {
                 cleanUpFile();
                 server.stop();
@@ -291,7 +320,7 @@ test void testServer() {
 void executeEchoTest(String name) {
     //TODO log debug
     print("Making request to Ceylon server...");
-    
+
     value expecting = "Hello ``name``!";
 
     value request = ClientRequest(parse("http://localhost:8080/echo?name=" + name));
@@ -306,16 +335,16 @@ void executeEchoTest(String name) {
 
 void headerTest() {
     String contentType = "application/x-www-form-urlencoded";
-    
+
     value request = ClientRequest(parse("http://localhost:8080/headerTest"));
     request.setHeader("Content-Type", contentType);
-    
+
     value response = request.execute();
 
     value echoMsg = response.contents;
     //TODO log debug
     print("Received contents: ``echoMsg``");
-    
+
     value contentTypeHeader = response.getSingleHeader("Content-Type");
     response.close();
 
@@ -350,23 +379,23 @@ void fileMapperTest() {
 
 void concurentFileRequests(Integer concurentRequests) {
     variable Integer requestNumber = 0;
-    
+
     object user satisfies Runnable {
         shared actual void run() {
             executeTestStaticFile(requestsPerUser);
         }
     }
-    
+
     value users = LinkedList<Thread>();
 
-    print ("Running ``concurentRequests `` concurent requests.");    
+    print ("Running ``concurentRequests `` concurent requests.");
     while(requestNumber < concurentRequests) {
         value userThread = Thread(user);
         users.add(userThread);
         userThread.start();
         requestNumber++;
     }
-    
+
     //wait for users to complete requests
     for (userThread in users) {
         userThread.join();
@@ -401,7 +430,7 @@ void cleanUpFile() {
 
 test void testPathMatcher() {
     String requestPath = "/file/myfile.txt";
-    
+
     value matcherStarts = startsWith("/file");
     assertTrue(matcherStarts.matches(requestPath));
 
@@ -410,10 +439,10 @@ test void testPathMatcher() {
 
     value matcher = startsWith("/file");
     assertEquals("/myfile.txt", matcher.relativePath(requestPath));
-    
+
     value matcher2 = endsWith(".txt");
     assertEquals("/file/myfile.txt", matcher2.relativePath(requestPath));
-    
+
     value matcher3 = startsWith("/file").and(endsWith(".txt"));
     assertEquals("/file/myfile.txt", matcher3.relativePath(requestPath));
 
@@ -426,7 +455,7 @@ test void testPathMatcher() {
     assertEquals("/myfile.txt", matcher5.relativePath(requestPath));
 
     value matcher6 = (startsWith("/blob")
-            .or(startsWith("/file")) 
+            .or(startsWith("/file"))
             .and(endsWith(".txt")));
     assertEquals("/file/myfile.txt", matcher6.relativePath(requestPath));
 }
@@ -495,7 +524,7 @@ void acceptMethodTest() {
     //TODO log
     assertEquals(response1Status, 200);
 
-    //do NOT accept PUT 
+    //do NOT accept PUT
     value request2 = ClientRequest(parse("http://localhost:8080/acceptMethodTest"));
     request2.method = put;
     request2.setParameter(Parameter("foo", "valueFoo"));
@@ -565,6 +594,52 @@ void parametersTest(String paramKey, String paramValue) {
     assertEquals(paramValue, responseContent);
 }
 
+void formParametersTest(String paramKey, String+ paramValues) {
+    value request = ClientRequest(parse("http://localhost:8080/formParamsTest?``paramKey``=notThis"), post);
+
+    request.setHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
+    request.setParameter(Parameter("foo", "valueFoo"));
+    for (String val in paramValues) {
+        request.setParameter(Parameter(paramKey, val));
+    }
+
+    value response = request.execute();
+    value responseContent = response.contents;
+    response.close();
+    //TODO log
+    print("Response content: " + responseContent);
+    assertEquals(responseContent, paramValues.string);
+}
+
+void formParameterTest(String paramKey, String+ paramValues) {
+    value request = ClientRequest(parse("http://localhost:8080/formParamTest?``paramKey``=notThis"), post);
+
+    request.setHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
+    request.setParameter(Parameter("foo", "valueFoo"));
+    for (String val in paramValues) {
+        request.setParameter(Parameter(paramKey, val));
+    }
+
+    value response = request.execute();
+    value responseContent = response.contents;
+    response.close();
+    //TODO log
+    print("Response content: " + responseContent);
+    assertEquals(responseContent, paramValues.first.string);
+}
+
+void readBinaryTest(Byte* bytes) {
+    value request = ClientRequest(parse("http://localhost:8080/readBinary"), post);
+
+    request.data = newByteBufferWithData(*bytes);
+
+    value response = request.execute();
+    value body = response.contents;
+
+    value expected = bytes.map((Byte b) => b.unsigned);
+    assertEquals(body, expected.string);
+}
+
 void writeStringsTest() {
     value request = ClientRequest(parse("http://localhost:8080/writeStrings"), get);
 
@@ -596,7 +671,7 @@ void sessionTest() {
 
 void testSerializer() {
     value request = ClientRequest(parse("http://localhost:8080/serializer"), get);
-    
+
     value response = request.execute();
     value responseContent = response.contents;
     //TODO log
@@ -642,7 +717,7 @@ void testAsyncStream() {
         process.write("``read``.");
     }
     print("Read in ``system.milliseconds - startTime``ms.");
-    
+
     ByteBuffer contentBuff = newByteBuffer(content.size);
     for (b in content) {
         contentBuff.putByte(b);

--- a/test-source/test/ceylon/net/server.ceylon
+++ b/test-source/test/ceylon/net/server.ceylon
@@ -119,9 +119,23 @@ test void testServer() {
         Endpoint {
             service => void (Request request, Response response) {
                 response.addHeader(contentType("text/html", utf8));
-                response.writeString(request.formParameters("aKey")?.string else "");
+                response.writeString(request.formParameters("aKey").string);
             };
             path = startsWith("/formParamsTest");
+        },
+        Endpoint {
+            service => void (Request request, Response response) {
+                response.addHeader(contentType("text/html", utf8));
+                response.writeString(request.queryParameter("aKey")?.string else "");
+            };
+            path = startsWith("/queryParamTest");
+        },
+        Endpoint {
+            service => void (Request request, Response response) {
+                response.addHeader(contentType("text/html", utf8));
+                response.writeString(request.queryParameters("aKey").string);
+            };
+            path = startsWith("/queryParamsTest");
         },
         Endpoint {
             service => void (Request request, Response response) {
@@ -280,6 +294,9 @@ test void testServer() {
                 formParametersTest("aKey", "aValue", "val2");
 
                 formParameterTest("aKey", "aValue", "val2");
+                
+                queryParametersTest("aKey", "aValue");
+                queryParameterTest("aKey", "aValue");
 
                 writeStringsTest();
 
@@ -625,7 +642,47 @@ void formParameterTest(String paramKey, String+ paramValues) {
     response.close();
     //TODO log
     print("Response content: " + responseContent);
-    assertEquals(responseContent, paramValues.first.string);
+    assertEquals(responseContent, paramValues.first);
+}
+
+void queryParametersTest(String paramKey, String+ paramValues) {
+	variable String query = "``paramKey``=``paramValues.first``";
+	for (String val in paramValues.rest) {
+		query = query + "&\`\`paramKey\`\`=\`\`paramValues.first\`\`";
+	}
+	print(query);
+	value request = ClientRequest(parse("http://localhost:8080/queryParamsTest?``query``"), post);
+	
+	request.setHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
+	request.setParameter(Parameter("foo", "valueFoo"));
+	request.setParameter(Parameter(paramKey, "valueBar"));
+	
+	value response = request.execute();
+	value responseContent = response.contents;
+	response.close();
+	//TODO log
+	print("Response content: " + responseContent);
+	assertEquals(responseContent, paramValues.string);
+}
+
+void queryParameterTest(String paramKey, String+ paramValues) {
+	variable String query = "``paramKey``=``paramValues.first``";
+	for (String val in paramValues.rest) {
+		query = query + "&\`\`paramKey\`\`=\`\`paramValues.first\`\`";
+	}
+	print(query);
+	value request = ClientRequest(parse("http://localhost:8080/queryParamTest?``query``"), post);
+	
+	request.setHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
+	request.setParameter(Parameter("foo", "valueFoo"));
+	request.setParameter(Parameter(paramKey, "valueBar"));
+	
+	value response = request.execute();
+	value responseContent = response.contents;
+	response.close();
+	//TODO log
+	print("Response content: " + responseContent);
+	assertEquals(responseContent, paramValues.first);
 }
 
 void readBinaryTest(Byte* bytes) {


### PR DESCRIPTION
Reading request body data as binary (byte array) was not possible, only String without being able to specify the encoding explicitly.
Further, query parameters and form parameters were merged in the existing implementation. It was not possible to examine the form parameters only.

RequestImpl.readBinary is not pretty as it copies the content byte array twice. I did not find a means to omit that. Tried implementing a ceylon.io.FileDescriptor for reading from the Java InputStream, but that is only possible in ceylon.io (sealed interface). I guess some more java interop for IO would be needed.