### PR TITLE
make test pass even when github changes their api

### DIFF
--- a/test-source/test/ceylon/net/connection.ceylon
+++ b/test-source/test/ceylon/net/connection.ceylon
@@ -38,7 +38,7 @@ import ceylon.io.charset {
 }
 
 void testJSON(Object json) {
-    assertEquals(70, json.size, "Object size");
+    assertTrue(json.size > 60, "Object size");
     assertEquals("http://ceylon-lang.org", json["homepage"], "Homepage");
     
     if (is Object owner = json["owner"]) {


### PR DESCRIPTION
The test expected exactly 70 entries in the object returned from
https://api.github.com/repos/ceylon/ceylon-compiler and started failing
once github started returning an object with 71 entries.