### PR TITLE
replace ceylon.numeric with code from xmath

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -95,6 +95,7 @@
             <module name="test.ceylon.io"/>
             <module name="test.ceylon.json"/>
             <module name="test.ceylon.net"/>
+            <module name="test.ceylon.numeric"/>
             <module name="test.ceylon.process"/>
             <module name="test.ceylon.promise"/>
             <module name="test.ceylon.time"/>
@@ -113,6 +114,7 @@
             <module name="test.ceylon.collection"/>
             <module name="test.ceylon.html"/>
             <module name="test.ceylon.json"/>
+            <module name="test.ceylon.numeric"/>
             <module name="test.ceylon.promise"/>
             <module name="test.ceylon.time"/>
             <module name="test.ceylon.locale"/>

--- a/source/ceylon/numeric/float/constants.ceylon
+++ b/source/ceylon/numeric/float/constants.ceylon
@@ -1,49 +1,15 @@
-import java.lang {
-    JMath=Math
-}
-
-"The `Float` which best approximates the 
- mathematical constant \{#0001D452}, the 
+"The `Float` which best approximates the
+ mathematical constant \{#0001D452}, the
  base of the natural logarithm."
 see(`function exp`,`function log`)
-shared native Float e;
+shared Float e = 2.7182818284590452354;
 
-"The Float which best approximates the 
- mathematical constant \{#03C0}, the ratio 
- of the circumference of a circle to its 
+"The Float which best approximates the
+ mathematical constant \{#03C0}, the ratio
+ of the circumference of a circle to its
  diameter."
-shared native Float pi;
+shared Float pi = 3.14159265358979323846;
 
-"The `Float` which best approximates the 
- mathematical constant \{#0001D452}, the 
- base of the natural logarithm."
-see(`function exp`,`function log`)
-shared native("jvm") Float e => JMath.\iE;
+Float undefined = 0.0/0.0;
 
-"The Float which best approximates the 
- mathematical constant \{#03C0}, the ratio 
- of the circumference of a circle to its 
- diameter."
-shared native("jvm") Float pi => JMath.\iPI;
-
-"The `Float` which best approximates the 
- mathematical constant \{#0001D452}, the 
- base of the natural logarithm."
-see(`function exp`,`function log`)
-shared native("js") Float e {
-    dynamic {
-        return Math.\iE;
-    }
-}
-
-"The Float which best approximates the 
- mathematical constant \{#03C0}, the ratio 
- of the circumference of a circle to its 
- diameter."
-shared native("js") Float pi {
-    dynamic {
-        return Math.\iPI;
-    }
-}
-
-
+Float twoFiftyTwo = (2^52).float;

--- a/source/ceylon/numeric/float/functions.ceylon
+++ b/source/ceylon/numeric/float/functions.ceylon
@@ -1,884 +1,321 @@
 import java.lang {
-    JMath=Math
+    JVMMath=Math
 }
 
 "\{#0001D452} raised to the power of the argument.
- 
+
  * `exp(-infinity)` is `+0`,
  * `exp(+infinity)` is `+infinity`,
  * `exp(undefined)` is `undefined`.
  "
 see (`function expm1`)
-shared native Float exp(Float num);
+shared native
+Float exp(Float num);
 
-"The natural logarithm (base \{#0001D452}) of the 
- argument.
- 
- * `log(x)` for any x < 0 is `undefined`,
- * `log(+0)` and `log(-0)` is `-infinity`,
- * `log(+infinity)` is `+infinity`,
- * `log(undefined)` is `undefined`.
- "
-see(`function log10`, `function log1p`)
-shared native Float log(Float num);
+shared native("jvm")
+Float exp(Float num)
+    =>  JVMMath.exp(num);
 
-"The base 10 logarithm of the argument.
- 
- * `log10(x)` for any x < 0 is `undefined`,
- * `log10(-0)` and `log10(+0)` is `-infinity`,
- * `log10(+infinity)` is `+infinity`,
- * `log10(undefined)` is `undefined`.
- "
-see(`function log`)
-shared native Float log10(Float num);
-
-"The sine of the given angle specified in radians.
- 
- * `sin(-0)` is `-0`,
- * `sin(+0)` is `+0`,
- * `sin(-infinity)` is `undefined`,
- * `sin(+infinity)` is `undefined`,
- * `sin(undefined)` is `undefined`.
- "
-shared native Float sin(Float num);
-
-"The cosine of the given angle specified in radians.
- 
- * `cos(-infinity)` is `undefined`,
- * `cos(+infinity)` is `undefined`,
- * `cos(undefined)` is `undefined`.
- "
-shared native Float cos(Float num);
-
-"The tangent of the given angle specified in radians.
- 
- * `tan(-infinity)` is `undefined`,
- * `tan(-0)` is `-0`,
- * `tan(+0)` is `+0`,
- * `tan(+infinity)` is `undefined`,
- * `tan(undefined)` is `undefined`.
- "
-shared native Float tan(Float num);
-
-"The hyperbolic sine of the given angle specified in 
- radians.
- 
- * `sinh(-0)` is `-0`,
- * `sinh(+0)` is `+0`,
- * `sin(-infinity)` is `-infinity`,
- * `sin(+infinity)` is `+infinity`,
- * `sin(undefined)` is `undefined`.
- "
-shared native Float sinh(Float num);
-
-"The hyperbolic cosine of the given angle specified in 
- radians.
- 
- * `cosh(0)` is `1`.
- * `cosh(-infinity)` is `+infinity`,
- * `cosh(+infinity)` is `+infinity`,
- * `cosh(undefined)` is `undefined`.
- "
-shared native Float cosh(Float num);
-
-"The hyperbolic tangent of the given angle specified in 
- radians.
- 
- * `tanh(+infinity)` is `+1`,
- * `tanh(-infinity)` is `-1`,
- * `tanh(-0)` is `-0`,
- * `tanh(+0)` is `+0`,
- * `tanh(undefined)` is `undefined`.
- "
-shared native Float tanh(Float num);
-
-"The arc sine of the given number.
- 
- * `asin(x)` for any x < -1 is `undefined`,
- * `asin(-0)` is `-0`,
- * `asin(+0)` is `+0`,
- * `asin(x)` for any x > 1 is `undefined`,
- * `asin(undefined) is `undefined`.
- "
-shared native Float asin(Float num);
-
-"The arc cosine of the given number.
- 
- * `acos(x)` for any x < -1 is `undefined`,
- * `acos(x)` for any x > 1 is `undefined`,
- * `acos(undefined) is `undefined`.
- "
-shared native Float acos(Float num);
-
-"The arc tangent of the given number.
- 
- * `atan(-0)` is `-0`,
- * `atan(+0)` is `+0`,
- * `atan(undefined)` is `undefined`.
- "
-shared native Float atan(Float num);
-
-"The angle from converting rectangular coordinates 
- `x` and `y` to polar coordinates.
- 
- Special cases:
- 
- <table>
- <tbody>
- <tr>
- <th><code>y</code></th>
- <th><code>x</code></th>
- <th><code>atan2(y,x)</code></th>
- </tr>
- 
- <tr>
- <td><code>undefined</code></td>
- <td>any value</td>
- <td><code>undefined</code></td>
- </tr>
- 
- <tr>
- <td>any value</td>
- <td><code>undefined</code></td>
- <td><code>undefined</code></td>
- </tr>
- 
- <tr><td><code>+0</code></td>
- <td><code>&gt; 0</code></td>
- <td><code>+0</code></td>
- </tr>
- 
- <tr>
- <td><code>&gt; 0</code> and not <code>+infinity</code></td>
- <td><code>+infinity</code></td>
- <td><code>+0</code></td></tr>
- 
- <tr>
- <td><code>-0</code></td>
- <td><code>&gt; 0</code></td>
- <td><code>-0</code></td>
- </tr>
- 
- <tr>
- <td><code>&lt; 0</code> and not <code>-infinity</code></td>
- <td><code>+infinity</code></td>
- <td><code>-0</code></td>
- </tr>
- 
- <tr>
- <td><code>+0</code></td>
- <td><code>&lt; 0</code></td>
- <td><code>\{#03C0}</code></td>
- </tr>
- 
- <tr>
- <td><code>&gt; 0</code> and not <code>+infinity</code></td>
- <td><code>-infinity</code></td>
- <td><code>\{#03C0}</code></td>
- </tr>
- 
- <tr>
- <td><code>-0</code></td>
- <td><code>&lt; 0</code></td>
- <td><code>-\{#03C0}</code></td>
- </tr>
- 
- <tr>
- <td><code>&lt; 0</code> and not <code>-infinity</code></td>
- <td><code>-infinity</code></td>
- <td><code>-\{#03C0}</code></td>
- </tr>
- 
- <tr>
- <td><code>&gt; 0</code></td>
- <td><code>+0 or -0</code></td>             
- <td><code>\{#03C0}/2</code></td>
- </tr>
- 
- <tr>
- <td><code>+infinity</code></td>
- <td>not <code>+infinity</code> or <code>-infinity</code></td>
- <td><code>\{#03C0}/2</code></td>
- </tr>
- 
- <tr>
- <td><code>&lt; 0</code></td>
- <td><code>+0 or -0</code></td>
- <td><code>-\{#03C0}/2</code></td>
- </tr>
- 
- <tr>
- <td><code>-infinity</code></td>
- <td>not <code>+infinity</code> or <code>-infinity</code></td>
- <td><code>-\{#03C0}/2</code></td>
- </tr>
- 
- <tr>
- <td><code>+infinity</code></td>
- <td><code>+infinity</code></td>
- <td><code>\{#03C0}/4</code></td>
- </tr>
- 
- <tr>
- <td><code>+infinity</code></td>
- <td><code>-infinity</code></td>
- <td><code>3\{#03C0}/4</code></td>
- </tr>
- 
- <tr>
- <td><code>-infinity</code></td>
- <td><code>+infinity</code></td>
- <td><code>-\{#03C0}/4</code></td>
- </tr>
- 
- <tr>
- <td><code>-infinity</code></td>
- <td><code>-infinity</code></td>
- <td><code>-3\{#03C0}/4</code></td>
- </tr>
- 
- </tbody>
- </table>
- "
-shared native Float atan2(Float y, Float x);
-
-"Returns the length of the hypotenuse of a right angle 
- triangle with other sides having lengths `x` and `y`. 
- This method may be more accurate than computing 
- `sqrt(x^2 + x^2)` directly.
- 
- * `hypot(x,y)` where `x` and/or `y` is `+infinity` or 
-   `-infinity`, is `+infinity`,
- * `hypot(x,y)`, where `x` and/or `y` is `undefined`, 
-   is `undefined`.
- "
-shared native Float hypot(Float x, Float y);
-
-"The positive square root of the given number. This 
- method may be faster and/or more accurate than 
- `num^0.5`.
- 
- * `sqrt(x)` for any x < 0 is `undefined`,
- * `sqrt(-0)` is `-0`,
- * `sqrt(+0) is `+0`,
- * `sqrt(+infinity)` is `+infinity`,
- * `sqrt(undefined)` is `undefined`.     
- "
-shared native Float sqrt(Float num);
-
-"The cube root of the given number. This method may be 
- faster and/or more accurate than `num^(1.0/3.0)`.
- 
- * `cbrt(-infinity)` is `-infinity`,
- * `cbrt(-0)` is `-0`,
- * `cbrt(+0)` is `+0`,
- * `cbrt(+infinity)` is `+infinity`,
- * `cbrt(undefined)` is `undefined`.    
- "
-shared native Float cbrt(Float num);
-
-"A number greater than or equal to positive zero and less 
- than `1.0`, chosen pseudorandomly and (approximately) 
- uniformly distributed."
-shared native Float random();
-
-"The largest value that is less than or equal to the 
- argument and equal to an integer.
- 
- * `floor(-infinity)` is `-infinity`,
- * `floor(-0)` is `-0`,
- * `floor(+0)` is `+0`,
- * `floor(+infinity)` is `+infinity`,
- * `floor(undefined)` is `undefined`.
- "
-see(`function ceiling`)
-see(`function round`)
-shared native Float floor(Float num);
-
-"The smallest value that is greater than or equal to the 
- argument and equal to an integer.
- 
- * `ceiling(-infinity)` is `-infinity`,
- * `ceiling(x)` for -1.0 < x < -0 is `-0`,
- * `ceiling(-0)` is `-0`,
- * `ceiling(+0)` is `+0`,
- * `ceiling(+infinity)` is `+infinity`,
- * `ceiling(undefined)` is `undefined`.
- "
-see(`function floor`)
-see(`function round`)
-shared native Float ceiling(Float num);
-
-"The closest value to the argument that is equal to a
- mathematical integer, with even values preferred in the 
- event of a tie (half even rounding).
- 
- * `round(-infinity)` is `-infinity`
- * `round(-0)` is `-0` 
- * `round(+0)` is `+0`
- * `round(+infinity)` is `+infinity`
- * `round(undefined)` is `undefined`
- "
-see(`function floor`)
-see(`function ceiling`)
-shared native Float round(Float num);
-
-"The smaller of the two arguments.
- 
- * `smallest(-1,+0)` is `-0`
- * `smallest(undefined, x)` is `undefined`
- * `smallest(x, x)` is `x`
- * `smallest(+infinity,x) is `x`
- * `smallest(-infinity,x) is `-infinity`
- "
-see(`function largest`)
-shared native Float smallest(Float x, Float y);
-
-"The larger of the two arguments.
- 
- * `largest(-1,+0)` is `+0`
- * `largest(undefined, x)` is `undefined`
- * `largest(x, x)` is `x`
- * `largest(+infinity,x) is `+infinity`
- * `largest(-infinity,x) is `x`
- "
-see(`function smallest`)
-shared native Float largest(Float x, Float y);
-
-"\{#0001D452} raised to the power of the argument.
- 
- * `exp(-infinity)` is `+0`,
- * `exp(+infinity)` is `+infinity`,
- * `exp(undefined)` is `undefined`.
- "
-see (`function expm1`)
-shared native("jvm") Float exp(Float num) 
-        => JMath.exp(num);
-
-"The natural logarithm (base \{#0001D452}) of the 
- argument.
- 
- * `log(x)` for any x < 0 is `undefined`,
- * `log(+0)` and `log(-0)` is `-infinity`,
- * `log(+infinity)` is `+infinity`,
- * `log(undefined)` is `undefined`.
- "
-see(`function log10`, `function log1p`)
-shared native("jvm") Float log(Float num) 
-        => JMath.log(num);
-
-"The base 10 logarithm of the argument.
- 
- * `log10(x)` for any x < 0 is `undefined`,
- * `log10(-0)` and `log10(+0)` is `-infinity`,
- * `log10(+infinity)` is `+infinity`,
- * `log10(undefined)` is `undefined`.
- "
-see(`function log`)
-shared native("jvm") Float log10(Float num) 
-        => JMath.log10(num);
-
-"The sine of the given angle specified in radians.
- 
- * `sin(-0)` is `-0`,
- * `sin(+0)` is `+0`,
- * `sin(-infinity)` is `undefined`,
- * `sin(+infinity)` is `undefined`,
- * `sin(undefined)` is `undefined`.
- "
-shared native("jvm") Float sin(Float num) 
-        => JMath.sin(num);
-
-"The cosine of the given angle specified in radians.
- 
- * `cos(-infinity)` is `undefined`,
- * `cos(+infinity)` is `undefined`,
- * `cos(undefined)` is `undefined`.
- "
-shared native("jvm") Float cos(Float num) 
-        => JMath.cos(num);
-
-"The tangent of the given angle specified in radians.
- 
- * `tan(-infinity)` is `undefined`,
- * `tan(-0)` is `-0`,
- * `tan(+0)` is `+0`,
- * `tan(+infinity)` is `undefined`,
- * `tan(undefined)` is `undefined`.
- "
-shared native("jvm") Float tan(Float num) 
-        => JMath.tan(num);
-
-"The hyperbolic sine of the given angle specified in 
- radians.
- 
- * `sinh(-0)` is `-0`,
- * `sinh(+0)` is `+0`,
- * `sin(-infinity)` is `-infinity`,
- * `sin(+infinity)` is `+infinity`,
- * `sin(undefined)` is `undefined`.
- "
-shared native("jvm") Float sinh(Float num) 
-        => JMath.sinh(num);
-
-"The hyperbolic cosine of the given angle specified in 
- radians.
- 
- * `cosh(0)` is `1`.
- * `cosh(-infinity)` is `+infinity`,
- * `cosh(+infinity)` is `+infinity`,
- * `cosh(undefined)` is `undefined`.
- "
-shared native("jvm") Float cosh(Float num) 
-        => JMath.cosh(num);
-
-"The hyperbolic tangent of the given angle specified in 
- radians.
- 
- * `tanh(+infinity)` is `+1`,
- * `tanh(-infinity)` is `-1`,
- * `tanh(-0)` is `-0`,
- * `tanh(+0)` is `+0`,
- * `tanh(undefined)` is `undefined`.
- "
-shared native("jvm") Float tanh(Float num) 
-        => JMath.tanh(num);
-
-"The arc sine of the given number.
- 
- * `asin(x)` for any x < -1 is `undefined`,
- * `asin(-0)` is `-0`,
- * `asin(+0)` is `+0`,
- * `asin(x)` for any x > 1 is `undefined`,
- * `asin(undefined) is `undefined`.
- "
-shared native("jvm") Float asin(Float num) 
-        => JMath.asin(num);
-
-"The arc cosine of the given number.
- 
- * `acos(x)` for any x < -1 is `undefined`,
- * `acos(x)` for any x > 1 is `undefined`,
- * `acos(undefined) is `undefined`.
- "
-shared native("jvm") Float acos(Float num) 
-        => JMath.acos(num);
-
-"The arc tangent of the given number.
- 
- * `atan(-0)` is `-0`,
- * `atan(+0)` is `+0`,
- * `atan(undefined)` is `undefined`.
- "
-shared native("jvm") Float atan(Float num) 
-        => JMath.atan(num);
-
-"The angle from converting rectangular coordinates 
- `x` and `y` to polar coordinates.
- 
- Special cases:
- 
- <table>
- <tbody>
- <tr>
- <th><code>y</code></th>
- <th><code>x</code></th>
- <th><code>atan2(y,x)</code></th>
- </tr>
- 
- <tr>
- <td><code>undefined</code></td>
- <td>any value</td>
- <td><code>undefined</code></td>
- </tr>
- 
- <tr>
- <td>any value</td>
- <td><code>undefined</code></td>
- <td><code>undefined</code></td>
- </tr>
- 
- <tr><td><code>+0</code></td>
- <td><code>&gt; 0</code></td>
- <td><code>+0</code></td>
- </tr>
- 
- <tr>
- <td><code>&gt; 0</code> and not <code>+infinity</code></td>
- <td><code>+infinity</code></td>
- <td><code>+0</code></td></tr>
- 
- <tr>
- <td><code>-0</code></td>
- <td><code>&gt; 0</code></td>
- <td><code>-0</code></td>
- </tr>
- 
- <tr>
- <td><code>&lt; 0</code> and not <code>-infinity</code></td>
- <td><code>+infinity</code></td>
- <td><code>-0</code></td>
- </tr>
- 
- <tr>
- <td><code>+0</code></td>
- <td><code>&lt; 0</code></td>
- <td><code>\{#03C0}</code></td>
- </tr>
- 
- <tr>
- <td><code>&gt; 0</code> and not <code>+infinity</code></td>
- <td><code>-infinity</code></td>
- <td><code>\{#03C0}</code></td>
- </tr>
- 
- <tr>
- <td><code>-0</code></td>
- <td><code>&lt; 0</code></td>
- <td><code>-\{#03C0}</code></td>
- </tr>
- 
- <tr>
- <td><code>&lt; 0</code> and not <code>-infinity</code></td>
- <td><code>-infinity</code></td>
- <td><code>-\{#03C0}</code></td>
- </tr>
- 
- <tr>
- <td><code>&gt; 0</code></td>
- <td><code>+0 or -0</code></td>             
- <td><code>\{#03C0}/2</code></td>
- </tr>
- 
- <tr>
- <td><code>+infinity</code></td>
- <td>not <code>+infinity</code> or <code>-infinity</code></td>
- <td><code>\{#03C0}/2</code></td>
- </tr>
- 
- <tr>
- <td><code>&lt; 0</code></td>
- <td><code>+0 or -0</code></td>
- <td><code>-\{#03C0}/2</code></td>
- </tr>
- 
- <tr>
- <td><code>-infinity</code></td>
- <td>not <code>+infinity</code> or <code>-infinity</code></td>
- <td><code>-\{#03C0}/2</code></td>
- </tr>
- 
- <tr>
- <td><code>+infinity</code></td>
- <td><code>+infinity</code></td>
- <td><code>\{#03C0}/4</code></td>
- </tr>
- 
- <tr>
- <td><code>+infinity</code></td>
- <td><code>-infinity</code></td>
- <td><code>3\{#03C0}/4</code></td>
- </tr>
- 
- <tr>
- <td><code>-infinity</code></td>
- <td><code>+infinity</code></td>
- <td><code>-\{#03C0}/4</code></td>
- </tr>
- 
- <tr>
- <td><code>-infinity</code></td>
- <td><code>-infinity</code></td>
- <td><code>-3\{#03C0}/4</code></td>
- </tr>
- 
- </tbody>
- </table>
- "
-shared native("jvm") Float atan2(Float y, Float x) 
-        => JMath.atan2(y, x);
-
-"Returns the length of the hypotenuse of a right angle 
- triangle with other sides having lengths `x` and `y`. 
- This method may be more accurate than computing 
- `sqrt(x^2 + x^2)` directly.
- 
- * `hypot(x,y)` where `x` and/or `y` is `+infinity` or 
-   `-infinity`, is `+infinity`,
- * `hypot(x,y)`, where `x` and/or `y` is `undefined`, 
-   is `undefined`.
- "
-shared native("jvm") Float hypot(Float x, Float y) 
-        => JMath.hypot(x, y);
-
-"The positive square root of the given number. This 
- method may be faster and/or more accurate than 
- `num^0.5`.
- 
- * `sqrt(x)` for any x < 0 is `undefined`,
- * `sqrt(-0)` is `-0`,
- * `sqrt(+0) is `+0`,
- * `sqrt(+infinity)` is `+infinity`,
- * `sqrt(undefined)` is `undefined`.     
- "
-shared native("jvm") Float sqrt(Float num) 
-        => JMath.sqrt(num);
-
-"The cube root of the given number. This method may be 
- faster and/or more accurate than `num^(1.0/3.0)`.
- 
- * `cbrt(-infinity)` is `-infinity`,
- * `cbrt(-0)` is `-0`,
- * `cbrt(+0)` is `+0`,
- * `cbrt(+infinity)` is `+infinity`,
- * `cbrt(undefined)` is `undefined`.    
- "
-shared native("jvm") Float cbrt(Float num) 
-        => JMath.cbrt(num);
-
-"A number greater than or equal to positive zero and less 
- than `1.0`, chosen pseudorandomly and (approximately) 
- uniformly distributed."
-shared native("jvm") Float random() 
-        => JMath.random();
-
-"The largest value that is less than or equal to the 
- argument and equal to an integer.
- 
- * `floor(-infinity)` is `-infinity`,
- * `floor(-0)` is `-0`,
- * `floor(+0)` is `+0`,
- * `floor(+infinity)` is `+infinity`,
- * `floor(undefined)` is `undefined`.
- "
-see(`function ceiling`)
-see(`function round`)
-shared native("jvm") Float floor(Float num) 
-        => JMath.floor(num);
-
-"The smallest value that is greater than or equal to the 
- argument and equal to an integer.
- 
- * `ceiling(-infinity)` is `-infinity`,
- * `ceiling(x)` for -1.0 < x < -0 is `-0`,
- * `ceiling(-0)` is `-0`,
- * `ceiling(+0)` is `+0`,
- * `ceiling(+infinity)` is `+infinity`,
- * `ceiling(undefined)` is `undefined`.
- "
-see(`function floor`)
-see(`function round`)
-shared native("jvm") Float ceiling(Float num) 
-        => JMath.ceil(num);
-
-"The closest value to the argument that is equal to a
- mathematical integer, with even values preferred in the 
- event of a tie (half even rounding).
- 
- * `round(-infinity)` is `-infinity`
- * `round(-0)` is `-0` 
- * `round(+0)` is `+0`
- * `round(+infinity)` is `+infinity`
- * `round(undefined)` is `undefined`
- "
-see(`function floor`)
-see(`function ceiling`)
-shared native("jvm") Float round(Float num) 
-        => JMath.rint(num);
-
-"The smaller of the two arguments.
- 
- * `smallest(-1,+0)` is `-0`
- * `smallest(undefined, x)` is `undefined`
- * `smallest(x, x)` is `x`
- * `smallest(+infinity,x) is `x`
- * `smallest(-infinity,x) is `-infinity`
- "
-see(`function largest`)
-shared native("jvm") Float smallest(Float x, Float y) 
-        => JMath.min(x, y);
-
-"The larger of the two arguments.
- 
- * `largest(-1,+0)` is `+0`
- * `largest(undefined, x)` is `undefined`
- * `largest(x, x)` is `x`
- * `largest(+infinity,x) is `+infinity`
- * `largest(-infinity,x) is `x`
- "
-see(`function smallest`)
-shared native("jvm") Float largest(Float x, Float y) 
-        => JMath.max(x, y);
-
-"\{#0001D452} raised to the power of the argument.
- 
- * `exp(-infinity)` is `+0`,
- * `exp(+infinity)` is `+infinity`,
- * `exp(undefined)` is `undefined`.
- "
-see (`function expm1`)
-shared native("js") Float exp(Float num) {
+shared native("js")
+Float exp(Float num) {
     dynamic {
         return Math.exp(num);
     }
 }
 
-"The natural logarithm (base \{#0001D452}) of the 
+"A more accurate computation of `exp(x)-1.0` for `x` near
+ zero."
+native shared Float expm1(Float num);
+
+native("jvm") shared Float expm1(Float num)
+    =>  JVMMath.expm1(num);
+
+native("js", "dart") shared Float expm1(Float num)
+    =>  exp(num) - 1.0;
+
+"The natural logarithm (base \{#0001D452}) of the
  argument.
- 
+
  * `log(x)` for any x < 0 is `undefined`,
  * `log(+0)` and `log(-0)` is `-infinity`,
  * `log(+infinity)` is `+infinity`,
  * `log(undefined)` is `undefined`.
  "
 see(`function log10`, `function log1p`)
-shared native("js") Float log(Float num) {
+shared native
+Float log(Float num);
+
+shared native("jvm")
+Float log(Float num)
+    =>  JVMMath.log(num);
+
+shared native("js")
+Float log(Float num) {
     dynamic {
         return Math.log(num);
     }
 }
 
+"A more accurate computation of `log(1.0+x)` for `x` near
+ zero."
+native shared
+Float log1p(Float num);
+
+native("jvm") shared
+Float log1p(Float num)
+    =>  JVMMath.log1p(num);
+
+native("js", "dart") shared
+Float log1p(Float num)
+    =>  log(num + 1.0);
+
 "The base 10 logarithm of the argument.
- 
+
  * `log10(x)` for any x < 0 is `undefined`,
  * `log10(-0)` and `log10(+0)` is `-infinity`,
  * `log10(+infinity)` is `+infinity`,
  * `log10(undefined)` is `undefined`.
  "
 see(`function log`)
-shared native("js") Float log10(Float num) {
+shared native
+Float log10(Float num);
+
+shared native("jvm")
+Float log10(Float num)
+    =>  JVMMath.log10(num);
+
+shared native("js")
+Float log10(Float num) {
     dynamic {
-        return Math.log10(num);
+        Float n = Math.log(num);
+        Float d = Math.\iLN10;
+        return n / d;
     }
 }
 
+"The given angle (in radians) converted to degrees."
+shared see(`function toRadians`)
+Float toDegrees(Float num)
+    =>  num/pi*180;
+
+"The given angle (in degrees) converted to radians."
+shared see(`function toDegrees`)
+Float toRadians(Float num)
+    => num/180*pi;
+
 "The sine of the given angle specified in radians.
- 
+
  * `sin(-0)` is `-0`,
  * `sin(+0)` is `+0`,
  * `sin(-infinity)` is `undefined`,
  * `sin(+infinity)` is `undefined`,
  * `sin(undefined)` is `undefined`.
  "
-shared native("js") Float sin(Float num) {
+shared native
+Float sin(Float num);
+
+shared native("jvm")
+Float sin(Float num)
+    =>  JVMMath.sin(num);
+
+shared native("js")
+Float sin(Float num) {
+    if (num == 0.0 && num.strictlyNegative) {
+        return -0.0;
+    }
     dynamic {
-        return Math.sin(num);
+        return \iMath.sin(num);
     }
 }
 
 "The cosine of the given angle specified in radians.
- 
+
  * `cos(-infinity)` is `undefined`,
  * `cos(+infinity)` is `undefined`,
  * `cos(undefined)` is `undefined`.
  "
-shared native("js") Float cos(Float num) {
+shared native
+Float cos(Float num);
+
+shared native("jvm")
+Float cos(Float num)
+    =>  JVMMath.cos(num);
+
+shared native("js")
+Float cos(Float num) {
     dynamic {
         return Math.cos(num);
     }
 }
 
 "The tangent of the given angle specified in radians.
- 
+
  * `tan(-infinity)` is `undefined`,
  * `tan(-0)` is `-0`,
  * `tan(+0)` is `+0`,
  * `tan(+infinity)` is `undefined`,
  * `tan(undefined)` is `undefined`.
  "
-shared native("js") Float tan(Float num) {
+shared native
+Float tan(Float num);
+
+shared native("jvm")
+Float tan(Float num)
+    =>  JVMMath.tan(num);
+
+shared native("js")
+Float tan(Float num) {
+    if (num == 0.0 && num.strictlyNegative) {
+        return -0.0;
+    }
     dynamic {
         return Math.tan(num);
     }
 }
 
-"The hyperbolic sine of the given angle specified in 
+"The hyperbolic sine of the given angle specified in
  radians.
- 
+
  * `sinh(-0)` is `-0`,
  * `sinh(+0)` is `+0`,
- * `sin(-infinity)` is `-infinity`,
- * `sin(+infinity)` is `+infinity`,
- * `sin(undefined)` is `undefined`.
+ * `sinh(-infinity)` is `-infinity`,
+ * `sinh(+infinity)` is `+infinity`,
+ * `sinh(undefined)` is `undefined`.
  "
-shared native("js") Float sinh(Float num) {
-    dynamic {
-        return Math.sinh(num);
-    }
-}
+shared native
+Float sinh(Float num);
 
-"The hyperbolic cosine of the given angle specified in 
+shared native("jvm")
+Float sinh(Float num)
+    =>  JVMMath.sinh(num);
+
+shared native("js", "dart")
+Float sinh(Float num)
+    =>  if (!num.finite || num.fractionalPart == 0.0)
+        then num
+        else (exp(num) - exp(-num)) / 2;
+
+"The hyperbolic cosine of the given angle specified in
  radians.
- 
+
  * `cosh(0)` is `1`.
  * `cosh(-infinity)` is `+infinity`,
  * `cosh(+infinity)` is `+infinity`,
  * `cosh(undefined)` is `undefined`.
  "
-shared native("js") Float cosh(Float num) {
-    dynamic {
-        return Math.cosh(num);
-    }
-}
+shared native
+Float cosh(Float num);
 
-"The hyperbolic tangent of the given angle specified in 
+shared native("jvm")
+Float cosh(Float num)
+    =>  JVMMath.cosh(num);
+
+shared native("js", "dart")
+Float cosh(Float num)
+    =>  (exp(num) + exp(-num)) / 2;
+
+"The hyperbolic tangent of the given angle specified in
  radians.
- 
+
  * `tanh(+infinity)` is `+1`,
  * `tanh(-infinity)` is `-1`,
  * `tanh(-0)` is `-0`,
  * `tanh(+0)` is `+0`,
  * `tanh(undefined)` is `undefined`.
  "
-shared native("js") Float tanh(Float num) {
-    dynamic {
-        return Math.tanh(num);
+shared native
+Float tanh(Float num);
+
+shared native("jvm")
+Float tanh(Float num)
+    =>  JVMMath.tanh(num);
+
+shared native("js", "dart")
+Float tanh(Float num) {
+    if (num.infinite) {
+        return num.sign.float;
     }
+    if (num.fractionalPart == 0.0) {
+        return num;
+    }
+    value pos = exp(num);
+    value neg = exp(-num);
+    return (pos - neg) / (pos + neg);
 }
 
 "The arc sine of the given number.
- 
+
  * `asin(x)` for any x < -1 is `undefined`,
  * `asin(-0)` is `-0`,
  * `asin(+0)` is `+0`,
  * `asin(x)` for any x > 1 is `undefined`,
  * `asin(undefined) is `undefined`.
  "
-shared native("js") Float asin(Float num) {
+shared native
+Float asin(Float num);
+
+shared native("jvm")
+Float asin(Float num)
+    =>  JVMMath.asin(num);
+
+shared native("js")
+Float asin(Float num) {
+    if (num == 0.0 && num.strictlyNegative) {
+        return -0.0;
+    }
     dynamic {
         return Math.asin(num);
     }
 }
 
 "The arc cosine of the given number.
- 
+
  * `acos(x)` for any x < -1 is `undefined`,
  * `acos(x)` for any x > 1 is `undefined`,
  * `acos(undefined) is `undefined`.
  "
-shared native("js") Float acos(Float num) {
+shared native
+Float acos(Float num);
+
+shared native("jvm")
+Float acos(Float num)
+    =>  JVMMath.acos(num);
+
+shared native("js")
+Float acos(Float num) {
     dynamic {
         return Math.acos(num);
     }
 }
 
 "The arc tangent of the given number.
- 
+
  * `atan(-0)` is `-0`,
  * `atan(+0)` is `+0`,
  * `atan(undefined)` is `undefined`.
  "
-shared native("js") Float atan(Float num) {
+shared native
+Float atan(Float num);
+
+shared native("jvm")
+Float atan(Float num)
+    =>  JVMMath.atan(num);
+
+shared native("js")
+Float atan(Float num) {
+    if (num == 0.0 && num.strictlyNegative) {
+        return -0.0;
+    }
     dynamic {
         return Math.atan(num);
     }
 }
 
-"The angle from converting rectangular coordinates 
+"The angle from converting rectangular coordinates
  `x` and `y` to polar coordinates.
- 
+
  Special cases:
- 
+
  <table>
  <tbody>
  <tr>
@@ -886,198 +323,263 @@ shared native("js") Float atan(Float num) {
  <th><code>x</code></th>
  <th><code>atan2(y,x)</code></th>
  </tr>
- 
+
  <tr>
  <td><code>undefined</code></td>
  <td>any value</td>
  <td><code>undefined</code></td>
  </tr>
- 
+
  <tr>
  <td>any value</td>
  <td><code>undefined</code></td>
  <td><code>undefined</code></td>
  </tr>
- 
+
  <tr><td><code>+0</code></td>
  <td><code>&gt; 0</code></td>
  <td><code>+0</code></td>
  </tr>
- 
+
  <tr>
  <td><code>&gt; 0</code> and not <code>+infinity</code></td>
  <td><code>+infinity</code></td>
  <td><code>+0</code></td></tr>
- 
+
  <tr>
  <td><code>-0</code></td>
  <td><code>&gt; 0</code></td>
  <td><code>-0</code></td>
  </tr>
- 
+
  <tr>
  <td><code>&lt; 0</code> and not <code>-infinity</code></td>
  <td><code>+infinity</code></td>
  <td><code>-0</code></td>
  </tr>
- 
+
  <tr>
  <td><code>+0</code></td>
  <td><code>&lt; 0</code></td>
  <td><code>\{#03C0}</code></td>
  </tr>
- 
+
  <tr>
  <td><code>&gt; 0</code> and not <code>+infinity</code></td>
  <td><code>-infinity</code></td>
  <td><code>\{#03C0}</code></td>
  </tr>
- 
+
  <tr>
  <td><code>-0</code></td>
  <td><code>&lt; 0</code></td>
  <td><code>-\{#03C0}</code></td>
  </tr>
- 
+
  <tr>
  <td><code>&lt; 0</code> and not <code>-infinity</code></td>
  <td><code>-infinity</code></td>
  <td><code>-\{#03C0}</code></td>
  </tr>
- 
+
  <tr>
  <td><code>&gt; 0</code></td>
- <td><code>+0 or -0</code></td>             
+ <td><code>+0 or -0</code></td>
  <td><code>\{#03C0}/2</code></td>
  </tr>
- 
+
  <tr>
  <td><code>+infinity</code></td>
  <td>not <code>+infinity</code> or <code>-infinity</code></td>
  <td><code>\{#03C0}/2</code></td>
  </tr>
- 
+
  <tr>
  <td><code>&lt; 0</code></td>
  <td><code>+0 or -0</code></td>
  <td><code>-\{#03C0}/2</code></td>
  </tr>
- 
+
  <tr>
  <td><code>-infinity</code></td>
  <td>not <code>+infinity</code> or <code>-infinity</code></td>
  <td><code>-\{#03C0}/2</code></td>
  </tr>
- 
+
  <tr>
  <td><code>+infinity</code></td>
  <td><code>+infinity</code></td>
  <td><code>\{#03C0}/4</code></td>
  </tr>
- 
+
  <tr>
  <td><code>+infinity</code></td>
  <td><code>-infinity</code></td>
  <td><code>3\{#03C0}/4</code></td>
  </tr>
- 
+
  <tr>
  <td><code>-infinity</code></td>
  <td><code>+infinity</code></td>
  <td><code>-\{#03C0}/4</code></td>
  </tr>
- 
+
  <tr>
  <td><code>-infinity</code></td>
  <td><code>-infinity</code></td>
  <td><code>-3\{#03C0}/4</code></td>
  </tr>
- 
+
  </tbody>
  </table>
  "
-shared native("js") Float atan2(Float y, Float x) {
+shared native
+Float atan2(Float y, Float x);
+
+shared native("jvm")
+Float atan2(Float y, Float x)
+    =>  JVMMath.atan2(y, x);
+
+shared native("js")
+Float atan2(Float y, Float x) {
+    if (y == 0.0 && y.strictlyNegative) {
+        if (x.positive) {
+            return -0.0;
+        }
+        else if (x.negative) {
+            return -pi;
+        }
+        else {
+            return undefined;
+        }
+    }
     dynamic {
         return Math.atan2(y, x);
     }
 }
 
-"Returns the length of the hypotenuse of a right angle 
- triangle with other sides having lengths `x` and `y`. 
- This method may be more accurate than computing 
+"Returns the length of the hypotenuse of a right angle
+ triangle with other sides having lengths `x` and `y`.
+ This method may be more accurate than computing
  `sqrt(x^2 + x^2)` directly.
- 
- * `hypot(x,y)` where `x` and/or `y` is `+infinity` or 
+
+ * `hypot(x,y)` where `x` and/or `y` is `+infinity` or
    `-infinity`, is `+infinity`,
- * `hypot(x,y)`, where `x` and/or `y` is `undefined`, 
+ * `hypot(x,y)`, where `x` and/or `y` is `undefined`,
    is `undefined`.
  "
-shared native("js") Float hypot(Float x, Float y) {
-    dynamic {
-        return Math.hypot(x, y);
+shared native
+Float hypot(Float x, Float y);
+
+shared native("jvm")
+Float hypot(Float x, Float y)
+    =>  JVMMath.hypot(x, y);
+
+shared native("js", "dart")
+Float hypot(Float x, Float y) {
+    if (x.infinite || y.infinite) {
+        return infinity;
+    }
+    else if (x.undefined || y.undefined) {
+        return undefined;
+    }
+    else {
+        return sqrt((x^2) + (y^2));
     }
 }
 
-"The positive square root of the given number. This 
- method may be faster and/or more accurate than 
+"The positive square root of the given number. This
+ method may be faster and/or more accurate than
  `num^0.5`.
- 
+
  * `sqrt(x)` for any x < 0 is `undefined`,
  * `sqrt(-0)` is `-0`,
  * `sqrt(+0) is `+0`,
  * `sqrt(+infinity)` is `+infinity`,
- * `sqrt(undefined)` is `undefined`.     
+ * `sqrt(undefined)` is `undefined`.
  "
-shared native("js") Float sqrt(Float num) {
+shared native
+Float sqrt(Float num);
+
+shared native("jvm")
+Float sqrt(Float num)
+    =>  JVMMath.sqrt(num);
+
+shared native("js")
+Float sqrt(Float num) {
+    if (num == 0.0 && num.strictlyNegative) {
+        return -0.0;
+    }
     dynamic {
         return Math.sqrt(num);
     }
 }
 
-"The cube root of the given number. This method may be 
+"The cube root of the given number. This method may be
  faster and/or more accurate than `num^(1.0/3.0)`.
- 
+
  * `cbrt(-infinity)` is `-infinity`,
  * `cbrt(-0)` is `-0`,
  * `cbrt(+0)` is `+0`,
  * `cbrt(+infinity)` is `+infinity`,
- * `cbrt(undefined)` is `undefined`.    
+ * `cbrt(undefined)` is `undefined`.
  "
-shared native("js") Float cbrt(Float num) {
-    dynamic {
-        return Math.cbrt(num);
-    }
-}
+shared native
+Float cbrt(Float num);
 
-"A number greater than or equal to positive zero and less 
- than `1.0`, chosen pseudorandomly and (approximately) 
+shared native("jvm")
+Float cbrt(Float num)
+    =>  JVMMath.cbrt(num);
+
+shared native("js", "dart")
+Float cbrt(Float num)
+    =>  if (num.negative) then
+            -(num.negated ^ (1.0/3.0))
+        else if (num == 0.0) then
+            num // positive or negative zero
+        else
+            num ^ (1.0/3.0);
+
+"A number greater than or equal to positive zero and less
+ than `1.0`, chosen pseudorandomly and (approximately)
  uniformly distributed."
-shared native("js") Float random() {
+shared native
+Float random();
+
+shared native("jvm")
+Float random()
+    =>  JVMMath.random();
+
+shared native("js")
+Float random() {
     dynamic {
         return Math.random();
     }
 }
 
-"The largest value that is less than or equal to the 
+"The largest value that is less than or equal to the
  argument and equal to an integer.
- 
+
  * `floor(-infinity)` is `-infinity`,
  * `floor(-0)` is `-0`,
  * `floor(+0)` is `+0`,
  * `floor(+infinity)` is `+infinity`,
  * `floor(undefined)` is `undefined`.
  "
-see(`function ceiling`)
-see(`function round`)
-shared native("js") Float floor(Float num) {
-    dynamic {
-        return Math.floor(num);
-    }
-}
+shared see(`function halfEven`, `function ceiling`)
+Float floor(Float num)
+    =>  if (num.infinite ||
+                num.undefined ||
+                num.fractionalPart == 0.0) then
+            num
+        else if (num.negative) then
+            num.wholePart - 1.0
+        else
+            num.wholePart;
 
-"The smallest value that is greater than or equal to the 
+"The smallest value that is greater than or equal to the
  argument and equal to an integer.
- 
+
  * `ceiling(-infinity)` is `-infinity`,
  * `ceiling(x)` for -1.0 < x < -0 is `-0`,
  * `ceiling(-0)` is `-0`,
@@ -1085,72 +587,99 @@ shared native("js") Float floor(Float num) {
  * `ceiling(+infinity)` is `+infinity`,
  * `ceiling(undefined)` is `undefined`.
  "
-see(`function floor`)
-see(`function round`)
-shared native("js") Float ceiling(Float num) {
-    dynamic {
-        return Math.ceil(num);
-    }
-}
+shared see(`function floor`, `function halfEven`)
+Float ceiling(Float num)
+    =>  if (num.infinite ||
+                num.undefined ||
+                num.fractionalPart == 0.0) then
+            num
+        else if (num.negative) then
+            num.wholePart
+        else
+            num.wholePart + 1.0;
 
 "The closest value to the argument that is equal to a
- mathematical integer, with even values preferred in the 
+ mathematical integer, with even values preferred in the
  event of a tie (half even rounding).
- 
- * `round(-infinity)` is `-infinity`
- * `round(-0)` is `-0` 
- * `round(+0)` is `+0`
- * `round(+infinity)` is `+infinity`
- * `round(undefined)` is `undefined`
+
+ * `halfEven(-infinity)` is `-infinity`
+ * `halfEven(-0)` is `-0`
+ * `halfEven(+0)` is `+0`
+ * `halfEven(+infinity)` is `+infinity`
+ * `halfEven(undefined)` is `undefined`
  "
-see(`function floor`)
-see(`function ceiling`)
-shared native("js") Float round(Float num) {
-    dynamic {
-        return Math.round(num);
+shared see(`function floor`, `function ceiling`)
+Float halfEven(Float num) {
+    if (num.infinite ||
+            num.undefined ||
+            num.fractionalPart == 0.0) {
+        return num;
     }
+
+    variable value result = num.magnitude;
+    if (result >= twoFiftyTwo) {
+        return num;
+    }
+
+    // else, round
+    result = (twoFiftyTwo + result) - twoFiftyTwo;
+    return result * num.sign.float;
 }
 
 "The smaller of the two arguments.
- 
+
  * `smallest(-1,+0)` is `-0`
  * `smallest(undefined, x)` is `undefined`
  * `smallest(x, x)` is `x`
  * `smallest(+infinity,x) is `x`
  * `smallest(-infinity,x) is `-infinity`
  "
-see(`function largest`)
-shared native("js") Float smallest(Float x, Float y) {
-    dynamic {
-        return Math.min(x, y);
-    }
-}
+shared see(`function largest`)
+Float smallest(Float x, Float y)
+    =>  if (x.strictlyNegative && y.strictlyPositive) then
+            x
+        else if (x.strictlyPositive && y.strictlyNegative) then
+            y
+        else if (x.undefined || y.undefined) then
+            undefined
+        else if (x.smallerThan(y)) then
+            x
+        else
+            y;
 
 "The larger of the two arguments.
- 
+
  * `largest(-1,+0)` is `+0`
  * `largest(undefined, x)` is `undefined`
  * `largest(x, x)` is `x`
  * `largest(+infinity,x) is `+infinity`
  * `largest(-infinity,x) is `x`
  "
-see(`function smallest`)
-shared native("js") Float largest(Float x, Float y) {
-    dynamic {
-        return Math.max(x, y);
-    }
-}
+shared see(`function smallest`)
+Float largest(Float x, Float y)
+    =>  if (x.strictlyNegative && y.strictlyPositive) then
+            y
+        else if (x.strictlyPositive && y.strictlyNegative) then
+            x
+        else if (x.undefined || y.undefined) then
+            undefined
+        else if (x.largerThan(y)) then
+            x
+        else
+            y;
 
 "The largest [[Float]] in the given stream, or `null`
  if the stream is empty."
 shared Float|Absent max<Absent>
-        (Iterable<Float,Absent> values) 
+        (Iterable<Float,Absent> values)
         given Absent satisfies Null {
     value first = values.first;
     if (exists first) {
         variable value max = first;
         for (x in values) {
-            max = largest(max, x);
+            if (x>max) {
+                max = x;
+            }
         }
         return max;
     }
@@ -1160,22 +689,25 @@ shared Float|Absent max<Absent>
 "The smallest [[Float]] in the given stream, or `null`
  if the stream is empty."
 shared Float|Absent min<Absent>
-        (Iterable<Float,Absent> values) 
+        (Iterable<Float,Absent> values)
         given Absent satisfies Null {
     value first = values.first;
     if (exists first) {
         variable value min = first;
         for (x in values) {
-            min = smallest(min, x);
+            if (x<min) {
+                min = x;
+            }
         }
         return min;
     }
     return first;
 }
 
-"The sum of the [[Float]]s in the given stream, or `0.0` 
- if the stream is empty."
-shared Float sum({Float*} values) {
+"The sum of the values in the given stream, or
+ `0.0` if the stream is empty."
+shared
+Float sum({Float*} values) {
     variable Float sum=0.0;
     for (x in values) {
         sum+=x;
@@ -1183,65 +715,51 @@ shared Float sum({Float*} values) {
     return sum;
 }
 
-"The product of the [[Float]]s in the given stream, or `1.0` 
- if the stream is empty."
-shared Float product({Float*} values) {
-    variable Float sum=1.0;
+"The product of the values in the given stream, or
+ `1.0` if the stream is empty."
+shared
+Float product({Float*} values) {
+    variable Float product=1.0;
     for (x in values) {
-        sum*=x;
+        product*=x;
     }
-    return sum;
+    return product;
 }
 
-//"The value of `x \{#00D7} 2\{#207F}`, calculated exactly 
-// for reasonable values of `n`."
-//shared native Float scalb(Float x, Integer n);
+"The value of `x \{#00D7} 2\{#207F}`, calculated exactly
+ for reasonable values of `n` on JVM."
+shared native
+Float scalb(Float x, Integer n);
 
-"A more accurate computation of `log(1.0+x)` for `x` near
- zero."
-shared native Float log1p(Float num);
+shared native("jvm")
+Float scalb(Float x, Integer n)
+    =>  JVMMath.scalb(x, n);
 
-"A more accurate computation of `exp(x)-1.0` for `x` near
- zero."
-shared native Float expm1(Float num);
+shared native("js", "dart")
+Float scalb(Float x, Integer n)
+    // faster than other options per
+    // http://jsperf.com/scale-pow2/5
+    =>  x * 2.0 ^ n;
 
-//"The value of `x \{#00D7} 2\{#207F}`, calculated exactly 
-// for reasonable values of `n`."
-//shared native("jvm") Float scalb(Float x, Integer n) {
-//    return Math.scalb(x, n);
-//}
+"The remainder, after dividing the [[dividend]] by the [[divisor]]. This function is
+ defined as:
 
-"A more accurate computation of `log(1.0+x)` for `x` near
- zero."
-shared native("jvm") Float log1p(Float num) 
-        => JMath.log1p(num);
+     dividend - n * divisor
 
-"A more accurate computation of `exp(x)-1.0` for `x` near
- zero."
-shared native("jvm") Float expm1(Float num) 
-        => JMath.expm1(num);
+ where `n` is the whole part of `dividend / divisor`. The result will have the
+ same sign as the `dividend`.
 
-"A more accurate computation of `log(1.0+x)` for `x` near
- zero."
-shared native("js") Float log1p(Float num) {
-    dynamic {
-        return Math.log1p(num);
+ * `remainder(infinity, divisor)` is `undefined`,
+ * `remainder(dividend, 0.0)` is `undefined`,
+ * `remainder(dividend, infinity)` is `dividend` for non-infinite dividends."
+shared
+Float remainder(Float dividend, Float divisor) {
+    if (dividend == 0.0 && divisor != 0.0 && !divisor.undefined) {
+        return if (dividend.strictlyNegative) then -0.0 else 0.0;
     }
-}
-
-"A more accurate computation of `exp(x)-1.0` for `x` near
- zero."
-shared native("js") Float expm1(Float num) {
-    dynamic {
-        return Math.expm1(num);
+    if (divisor.infinite && !dividend.infinite) {
+        return dividend;
     }
+    // effectively, undefined is returned when divisor == 0.
+    return dividend - (dividend/divisor).wholePart * divisor;
 }
-
-"The given angle (in radians) converted to degrees."
-see(`function toRadians`)
-shared Float toDegrees(Float num) => num/pi*180;
-
-"The given angle (in degrees) converted to radians."
-see(`function toDegrees`)
-shared Float toRadians(Float num) => num/180*pi;
-

--- a/source/ceylon/numeric/float/functions.ceylon
+++ b/source/ceylon/numeric/float/functions.ceylon
@@ -30,7 +30,7 @@ native shared Float expm1(Float num);
 native("jvm") shared Float expm1(Float num)
     =>  JVMMath.expm1(num);
 
-native("js", "dart") shared Float expm1(Float num)
+native("js") shared Float expm1(Float num)
     =>  exp(num) - 1.0;
 
 "The natural logarithm (base \{#0001D452}) of the
@@ -65,7 +65,7 @@ native("jvm") shared
 Float log1p(Float num)
     =>  JVMMath.log1p(num);
 
-native("js", "dart") shared
+native("js") shared
 Float log1p(Float num)
     =>  log(num + 1.0);
 
@@ -189,7 +189,7 @@ shared native("jvm")
 Float sinh(Float num)
     =>  JVMMath.sinh(num);
 
-shared native("js", "dart")
+shared native("js")
 Float sinh(Float num)
     =>  if (!num.finite || num.fractionalPart == 0.0)
         then num
@@ -210,7 +210,7 @@ shared native("jvm")
 Float cosh(Float num)
     =>  JVMMath.cosh(num);
 
-shared native("js", "dart")
+shared native("js")
 Float cosh(Float num)
     =>  (exp(num) + exp(-num)) / 2;
 
@@ -230,7 +230,7 @@ shared native("jvm")
 Float tanh(Float num)
     =>  JVMMath.tanh(num);
 
-shared native("js", "dart")
+shared native("js")
 Float tanh(Float num) {
     if (num.infinite) {
         return num.sign.float;
@@ -475,7 +475,7 @@ shared native("jvm")
 Float hypot(Float x, Float y)
     =>  JVMMath.hypot(x, y);
 
-shared native("js", "dart")
+shared native("js")
 Float hypot(Float x, Float y) {
     if (x.infinite || y.infinite) {
         return infinity;
@@ -531,7 +531,7 @@ shared native("jvm")
 Float cbrt(Float num)
     =>  JVMMath.cbrt(num);
 
-shared native("js", "dart")
+shared native("js")
 Float cbrt(Float num)
     =>  if (num.negative) then
             -(num.negated ^ (1.0/3.0))
@@ -735,7 +735,7 @@ shared native("jvm")
 Float scalb(Float x, Integer n)
     =>  JVMMath.scalb(x, n);
 
-shared native("js", "dart")
+shared native("js")
 Float scalb(Float x, Integer n)
     // faster than other options per
     // http://jsperf.com/scale-pow2/5

--- a/source/ceylon/numeric/integer/functions.ceylon
+++ b/source/ceylon/numeric/integer/functions.ceylon
@@ -1,51 +1,25 @@
-import java.lang {
-    JMath=Math
-}
-
 "The smaller of the two arguments."
-see(`function largest`)
-shared native Integer smallest(Integer x, Integer y);
+shared see(`function largest`)
+Integer smallest(Integer x, Integer y)
+    =>  if (x < y) then x else y;
 
 "The larger of the two arguments."
-see(`function smallest`)
-shared native Integer largest(Integer x, Integer y);
-
-"The smaller of the two arguments."
-see(`function largest`)
-shared native("jvm") Integer smallest(Integer x, Integer y) 
-        => JMath.min(x, y);
-
-"The larger of the two arguments."
-see(`function smallest`)
-shared native("jvm") Integer largest(Integer x, Integer y) 
-        => JMath.max(x, y);
-
-"The smaller of the two arguments."
-see(`function largest`)
-shared native("js") Integer smallest(Integer x, Integer y) {
-    dynamic {
-        return Math.min(x, y);
-    }
-}
-
-"The larger of the two arguments."
-see(`function smallest`)
-shared native("js") Integer largest(Integer x, Integer y) {
-    dynamic {
-        return Math.max(x, y);
-    }
-}
+shared see(`function smallest`)
+Integer largest(Integer x, Integer y)
+    =>  if (x > y) then x else y;
 
 "The largest [[Integer]] in the given stream, or `null`
  if the stream is empty."
 shared Integer|Absent max<Absent>
-        (Iterable<Integer,Absent> values) 
+        (Iterable<Integer,Absent> values)
         given Absent satisfies Null {
     value first = values.first;
     if (exists first) {
         variable value max = first;
         for (x in values) {
-            max = largest(max, x);
+            if (x>max) {
+                max = x;
+            }
         }
         return max;
     }
@@ -55,22 +29,25 @@ shared Integer|Absent max<Absent>
 "The smallest [[Integer]] in the given stream, or `null`
  if the stream is empty."
 shared Integer|Absent min<Absent>
-        (Iterable<Integer,Absent> values) 
+        (Iterable<Integer,Absent> values)
         given Absent satisfies Null {
     value first = values.first;
     if (exists first) {
         variable value min = first;
         for (x in values) {
-            min = smallest(min, x);
+            if (x<min) {
+                min = x;
+            }
         }
         return min;
     }
     return first;
 }
 
-"The sum of the [[Integer]]s in the given stream, or `0` 
- if the stream is empty."
-shared Integer sum({Integer*} values) {
+"The sum of the values in the given stream, or
+ `0` if the stream is empty."
+shared
+Integer sum({Integer*} values) {
     variable Integer sum=0;
     for (x in values) {
         sum+=x;
@@ -78,12 +55,13 @@ shared Integer sum({Integer*} values) {
     return sum;
 }
 
-"The product of the [[Integer]]s in the given stream, or `1` 
- if the stream is empty."
-shared Integer product({Integer*} values) {
-    variable Integer sum=1;
+"The product of the values in the given stream, or
+ `1` if the stream is empty."
+shared
+Integer product({Integer*} values) {
+    variable Integer product=1;
     for (x in values) {
-        sum*=x;
+        product*=x;
     }
-    return sum;
+    return product;
 }

--- a/test-source/test/ceylon/numeric/floatTests.ceylon
+++ b/test-source/test/ceylon/numeric/floatTests.ceylon
@@ -1,0 +1,1312 @@
+import ceylon.test { assertEquals, assertTrue, assertFalse, test }
+import ceylon.numeric.float { ... }
+
+Float undefined = 0.0/0.0;
+
+Boolean approx(Anything expect, Anything got) {
+    if(exists expect){
+        if(exists got){
+            if (is Float expect) {
+                if (is Float got) {
+                    if (expect != expect
+                        && got != got) { // consider undefined as equal
+                        return true;
+                    }
+                    // TODO Use MPL to parameterize the tolerance
+                    return (expect - got).magnitude < 1.0E-10;
+                }
+            }
+        }
+        return false;
+    }
+    return !got exists;
+}
+
+Boolean exact(Anything expect, Anything got) {
+    if(exists expect){
+        if(exists got){
+            if (is Float expect) {
+                if (is Float got) {
+                    if (expect != expect
+                        && got != got) { // consider undefined as equal
+                        return true;
+                    } else if (expect == 0.0
+                        && got == 0.0
+                        && expect.strictlyPositive != got.strictlyPositive) { // consider 0.0 and -0.0 as different
+                        return false;
+                    }
+                    return expect == got;
+                }
+            }
+        }
+        return false;
+    }
+    return !got exists;
+}
+
+test void testExp() {
+    assertEquals{
+        expected=1.0;
+        actual=exp(0.0);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=+0.0;
+        actual=exp(-infinity);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=infinity;
+        actual=exp(infinity);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=undefined;
+        actual=exp(undefined);
+        compare=exact;
+    };
+}
+
+test void testExpm1() {
+    assertEquals{
+        expected=0.0;
+        actual=expm1(0.0);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=-1.0;
+        actual=expm1(-infinity);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=infinity;
+        actual=expm1(infinity);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=undefined;
+        actual=expm1(undefined);
+        compare=exact;
+    };
+}
+
+test void testLog() {
+    assertEquals{
+        expected=undefined;
+        actual=log(-1.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-infinity;
+        actual=log(-0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-infinity;
+        actual=log(+0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=log(e);
+        compare=exact;
+    };
+    assertEquals{
+        expected=infinity;
+        actual=log(infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=log(undefined);
+        compare=exact;
+    };
+}
+
+test void testLog1p() {
+    assertEquals{
+        expected=undefined;
+        actual=log1p(-2.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-infinity;
+        actual=log1p(-1.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=log1p(e - 1.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=infinity;
+        actual=log1p(infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=log1p(undefined);
+        compare=exact;
+    };
+}
+
+test void testLog10() {
+    assertEquals{
+        expected=undefined;
+        actual=log10(-1.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-infinity;
+        actual=log10(-0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-infinity;
+        actual=log10(+0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=log10(10.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=infinity;
+        actual=log10(infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=log10(undefined);
+        compare=exact;
+    };
+}
+
+test void testSin() {
+    assertEquals{
+        expected=undefined;
+        actual=sin(-infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-0.0;
+        actual=sin(-0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=0.0;
+        actual=sin(0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=sin(pi/2);
+        compare=approx;
+    };
+    assertEquals{
+        expected=0.0;
+        actual=sin(pi);
+        compare=approx;
+    };
+    assertEquals{
+        expected=-1.0;
+        actual=sin(pi*1.5);
+        compare=approx;
+    };
+    assertEquals{
+        expected=0.0;
+        actual=sin(2*pi);
+        compare=approx;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=sin(+infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=sin(undefined);
+        compare=exact;
+    };
+}
+
+test void testSinh() {
+    assertEquals{
+        expected=-infinity;
+        actual=sinh(-infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-0.0;
+        actual=sinh(-0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=0.0;
+        actual=sinh(0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-sinh(10.0);
+        actual=sinh(-10.0);
+        compare=approx;
+    };
+    assertEquals{
+        expected=+infinity;
+        actual=sinh(+infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=sinh(undefined);
+        compare=exact;
+    };
+}
+
+test void testCosh() {
+    assertEquals{
+        expected=+infinity;
+        actual=cosh(-infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=cosh(-0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=cosh(0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=cosh(10.0);
+        actual=cosh(-10.0);
+        compare=approx;
+    };
+    assertEquals{
+        expected=+infinity;
+        actual=cosh(+infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=cosh(undefined);
+        compare=exact;
+    };
+}
+
+test void testTanh() {
+    assertEquals{
+        expected=-1.0;
+        actual=tanh(-infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-0.0;
+        actual=tanh(-0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=0.0;
+        actual=tanh(0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-tanh(10.0);
+        actual=tanh(-10.0);
+        compare=approx;
+    };
+    assertEquals{
+        expected=+1.0;
+        actual=tanh(+infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=tanh(undefined);
+        compare=exact;
+    };
+}
+
+test void testCos() {
+    assertEquals{
+        expected=undefined;
+        actual=cos(-infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=cos(0.0);
+        compare=approx;
+    };
+    assertEquals{
+        expected=0.0;
+        actual=cos(pi/2);
+        compare=approx;
+    };
+    assertEquals{
+        expected=-1.0;
+        actual=cos(pi);
+        compare=approx;
+    };
+    assertEquals{
+        expected=0.0;
+        actual=cos(pi*1.5);
+        compare=approx;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=cos(2*pi);
+        compare=approx;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=cos(+infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=cos(undefined);
+        compare=exact;
+    };
+}
+
+test void testTan() {
+    assertEquals{
+        expected=undefined;
+        actual=tan(-infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-0.0;
+        actual=tan(-0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=0.0;
+        actual=tan(0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=tan(pi/4);
+        compare=approx;
+    };
+    assertEquals{
+        expected=-1.0;
+        actual=tan(0.75*pi);
+        compare=approx;
+    };
+    assertEquals{
+        expected=0.0;
+        actual=tan(pi);
+        compare=approx;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=tan(+infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=tan(undefined);
+        compare=exact;
+    };
+}
+
+test void testAsin() {
+    assertEquals{
+        expected=undefined;
+        actual=asin(-infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=asin(-2.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-0.0;
+        actual=asin(-0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=+0.0;
+        actual=asin(+0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=asin(2.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=asin(infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=asin(undefined);
+        compare=exact;
+    };
+}
+
+test void testAcos() {
+    assertEquals{
+        expected=undefined;
+        actual=acos(-infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=acos(-2.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=pi/2;
+        actual=acos(+0.0);
+        compare=approx;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=acos(2.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=acos(infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=acos(undefined);
+        compare=exact;
+    };
+}
+
+test void testAtan() {
+    assertEquals{
+        expected=-0.0;
+        actual=atan(-0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=+0.0;
+        actual=atan(+0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=atan(undefined);
+        compare=exact;
+    };
+}
+
+test void testAtan2() {
+    assertEquals{
+        expected=undefined;
+        actual=atan2(undefined, 0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=atan2(0.0, undefined);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=0.0;
+        actual=atan2(+0.0, 0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=+0.0;
+        actual=atan2(+0.0, 1.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=+0.0;
+        actual=atan2(1.0, +infinity);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=-0.0;
+        actual=atan2(-0.0, 1.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-0.0;
+        actual=atan2(-1.0, +infinity);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=pi;
+        actual=atan2(+0.0, -1.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=pi;
+        actual=atan2(1.0, -infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-pi;
+        actual=atan2(-0.0, -1.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-pi;
+        actual=atan2(-1.0, -infinity);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=pi/2;
+        actual=atan2(1.0, +0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=pi/2;
+        actual=atan2(1.0, -0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=pi/2;
+        actual=atan2(infinity, 1.0);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=-pi/2;
+        actual=atan2(-1.0, +0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-pi/2;
+        actual=atan2(-1.0, -0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-pi/2;
+        actual=atan2(-infinity, 1.0);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=pi/4;
+        actual=atan2(+infinity, +infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=3*pi/4;
+        actual=atan2(+infinity, -infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-pi/4;
+        actual=atan2(-infinity, +infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-3*pi/4;
+        actual=atan2(-infinity, -infinity);
+        compare=exact;
+    };
+}
+
+test void testHypot() {
+    assertEquals{
+        expected=0.0;
+        actual=hypot(0.0, 0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=infinity;
+        actual=hypot(0.0, infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=infinity;
+        actual=hypot(0.0, -infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=infinity;
+        actual=hypot(infinity, 0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=infinity;
+        actual=hypot(-infinity, 0.0);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=infinity;
+        actual=hypot(undefined, infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=infinity;
+        actual=hypot(undefined, -infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=infinity;
+        actual=hypot(infinity, undefined);
+        compare=exact;
+    };
+    assertEquals{
+        expected=infinity;
+        actual=hypot(-infinity, undefined);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=undefined;
+        actual=hypot(0.0, undefined);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=hypot(undefined, 0.0);
+        compare=exact;
+    };
+}
+
+test void testSqrt() {
+    assertEquals{
+        expected=undefined;
+        actual=sqrt(-infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=sqrt(-1.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-0.0;
+        actual=sqrt(-0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=+0.0;
+        actual=sqrt(+0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=sqrt(1.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=2.0;
+        actual=sqrt(4.0);
+        compare=approx;
+    };
+    assertEquals{
+        expected=infinity;
+        actual=sqrt(infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=sqrt(undefined);
+        compare=exact;
+    };
+}
+
+test void testCbrt() {
+    assertEquals{
+        expected=-infinity;
+        actual=cbrt(-infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-1.0;
+        actual=cbrt(-1.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-0.0;
+        actual=cbrt(-0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=+0.0;
+        actual=cbrt(+0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=cbrt(1.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=2.0;
+        actual=cbrt(8.0);
+        compare=approx;
+    };
+    assertEquals{
+        expected=infinity;
+        actual=cbrt(infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=cbrt(undefined);
+        compare=exact;
+    };
+}
+
+test void testRandom() {
+    for (Integer ii in 0..1000) {
+        Float r = random();
+        assertTrue(r >= +0.0, "random() returned ``r`` (must be >= +0)");
+        assertTrue(r < 1.0,  "random() returned ``r`` (must be < 1)");
+    }
+}
+
+test void testFloor() {
+    assertEquals{
+        expected=-infinity;
+        actual=floor(-infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-0.0;
+        actual=floor(-0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=+0.0;
+        actual=floor(+0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=+infinity;
+        actual=floor(+infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=floor(undefined);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=0.0;
+        actual=floor(0.1);
+        compare=exact;
+    };
+    assertEquals{
+        expected=0.0;
+        actual=floor(0.5);
+        compare=exact;
+    };
+    assertEquals{
+        expected=0.0;
+        actual=floor(0.9);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=1.0;
+        actual=floor(1.1);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=floor(1.5);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=floor(1.9);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=-1.0;
+        actual=floor(-0.1);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-1.0;
+        actual=floor(-0.5);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-1.0;
+        actual=floor(-0.9);
+        compare=exact;
+    };
+}
+
+test void testCeiling() {
+    assertEquals{
+        expected=-infinity;
+        actual=ceiling(-infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-0.0;
+        actual=ceiling(-0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=+0.0;
+        actual=ceiling(+0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=+infinity;
+        actual=ceiling(+infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=ceiling(undefined);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=1.0;
+        actual=ceiling(0.1);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=ceiling(0.5);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=ceiling(0.9);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=ceiling(1.0);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=2.0;
+        actual=ceiling(1.1);
+        compare=exact;
+    };
+    assertEquals{
+        expected=2.0;
+        actual=ceiling(1.5);
+        compare=exact;
+    };
+    assertEquals{
+        expected=2.0;
+        actual=ceiling(1.9);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=-0.0;
+        actual=ceiling(-0.1);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-0.0;
+        actual=ceiling(-0.5);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-0.0;
+        actual=ceiling(-0.9);
+        compare=exact;
+    };
+}
+
+test void testHalfEven() {
+    assertEquals{
+        expected=-infinity;
+        actual=halfEven(-infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-0.0;
+        actual=halfEven(-0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=+0.0;
+        actual=halfEven(+0.0);
+        compare=exact;
+    };
+    assertEquals{
+        expected=+infinity;
+        actual=halfEven(+infinity);
+        compare=exact;
+    };
+    assertEquals{
+        expected=undefined;
+        actual=halfEven(undefined);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=0.0;
+        actual=halfEven(0.1);
+        compare=exact;
+    };
+    assertEquals{
+        expected=0.0;
+        actual=halfEven(0.5);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=halfEven(0.9);
+        compare=exact;
+    };
+    assertEquals{
+        expected=1.0;
+        actual=halfEven(1.0);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=1.0;
+        actual=halfEven(1.1);
+        compare=exact;
+    };
+    assertEquals{
+        expected=2.0;
+        actual=halfEven(1.5);
+        compare=exact;
+    };
+    assertEquals{
+        expected=2.0;
+        actual=halfEven(1.9);
+        compare=exact;
+    };
+
+    assertEquals{
+        expected=-0.0;
+        actual=halfEven(-0.1);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-0.0;
+        actual=halfEven(-0.5);
+        compare=exact;
+    };
+    assertEquals{
+        expected=-1.0;
+        actual=halfEven(-0.9);
+        compare=exact;
+    };
+}
+
+test void testSumProduct() {
+    assertEquals {
+        expected = 0.0;
+        actual=sum {};
+        compare = exact;
+    };
+    assertEquals {
+        expected = 6.0;
+        actual=sum { 1.0, 2.0, 3.0 };
+        compare = exact;
+    };
+    assertEquals {
+        expected = 1.0;
+        actual=product {};
+        compare = exact;
+    };
+    assertEquals {
+        expected = 6.0;
+        actual=product { 1.0, 2.0, 3.0 };
+        compare = exact;
+    };
+}
+
+test void testScalb() {
+    // TODO scalb(-0.0, x) is -0.0 on JVM, +0.0 on JS
+    assertEquals {
+        expected = 0.0;
+        actual=scalb(0.0, 0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = 0.0;
+        actual=scalb(0.0, 2);
+        compare = exact;
+    };
+    assertEquals {
+        expected = 0.0;
+        actual=scalb(0.0, -2);
+        compare = exact;
+    };
+    assertEquals {
+        expected = 4.0;
+        actual=scalb(1.0, 2);
+        compare = exact;
+    };
+    assertEquals {
+        expected = 0.25;
+        actual=scalb(1.0, -2);
+        compare = exact;
+    };
+    assertEquals {
+        expected = -4.0;
+        actual=scalb(-1.0, 2);
+        compare = exact;
+    };
+    assertEquals {
+        expected = -0.25;
+        actual=scalb(-1.0, -2);
+        compare = exact;
+    };
+    assertEquals {
+        expected = 24.0;
+        actual=scalb(3.0, 3);
+        compare = exact;
+    };
+    assertEquals {
+        expected = 0.375;
+        actual=scalb(3.0, -3);
+        compare = exact;
+    };
+    assertEquals {
+        expected = -24.0;
+        actual=scalb(-3.0, 3);
+        compare = exact;
+    };
+    assertEquals {
+        expected = -0.375;
+        actual=scalb(-3.0, -3);
+        compare = exact;
+    };
+}
+
+test void testRemainder() {
+    assertEquals {
+        expected = 1.0;
+        actual=remainder(5.5, 1.5);
+        compare = exact;
+    };
+    assertEquals {
+        expected = 1.0;
+        actual=remainder(5.5, -1.5);
+        compare = exact;
+    };
+    assertEquals {
+        expected = -1.0;
+        actual=remainder(-5.5, 1.5);
+        compare = exact;
+    };
+    assertEquals {
+        expected = -1.0;
+        actual=remainder(-5.5, -1.5);
+        compare = exact;
+    };
+    // zero dividend
+    assertEquals {
+        expected = 0.0;
+        actual=remainder(0.0, 1.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = -0.0;
+        actual=remainder(-0.0, 1.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = 0.0;
+        actual=remainder(0.0, infinity);
+        compare = exact;
+    };
+    assertEquals {
+        expected = 0.0;
+        actual=remainder(0.0, -infinity);
+        compare = exact;
+    };
+    assertEquals {
+        expected = -0.0;
+        actual=remainder(-0.0, infinity);
+        compare = exact;
+    };
+    assertEquals {
+        expected = -0.0;
+        actual=remainder(-0.0, -infinity);
+        compare = exact;
+    };
+    assertEquals {
+        expected = 0.0 / 0.0; // undefined
+        actual=remainder(0.0, 0.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = -0.0 / 0.0; // undefined
+        actual=remainder(-0.0, 0.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(0.0, undefined);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(-0.0, undefined);
+        compare = exact;
+    };
+    // infinite dividend (always undefined)
+    assertEquals {
+        expected = undefined;
+        actual=remainder(infinity, 0.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(infinity, -0.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(infinity, 1.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(infinity, -1.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(infinity, undefined);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(infinity, -undefined);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(infinity, infinity);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(infinity, -infinity);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(-infinity, 0.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(-infinity, -0.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(-infinity, 1.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(-infinity, -1.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(-infinity, infinity);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(-infinity, -infinity);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(-infinity, undefined);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(-infinity, -undefined);
+        compare = exact;
+    };
+    // zero divisor
+    assertEquals {
+        expected = undefined;
+        actual=remainder(1.0, 0.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(-1.0, 0.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(undefined, 0.0);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(undefined, 0.0);
+        compare = exact;
+    };
+    // infinite divisor
+    assertEquals {
+        expected = 1.5;
+        actual=remainder(1.5, infinity);
+        compare = exact;
+    };
+    assertEquals {
+        expected = 1.5;
+        actual=remainder(1.5, -infinity);
+        compare = exact;
+    };
+    assertEquals {
+        expected = -1.5;
+        actual=remainder(-1.5, infinity);
+        compare = exact;
+    };
+    assertEquals {
+        expected = -1.5;
+        actual=remainder(-1.5, -infinity);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(undefined, infinity);
+        compare = exact;
+    };
+    assertEquals {
+        expected = undefined;
+        actual=remainder(undefined, -infinity);
+        compare = exact;
+    };
+}
+
+test void floatTests() {
+    assertFalse(exact(0.0, -0.0), "Oops! Test is broken because we can't distinguish 0.0 and -0.0");
+}

--- a/test-source/test/ceylon/numeric/integerTests.ceylon
+++ b/test-source/test/ceylon/numeric/integerTests.ceylon
@@ -1,0 +1,23 @@
+import ceylon.test { ... }
+import ceylon.numeric.integer { ... }
+
+test void testIntSumProduct() {
+    print("Integer.sum");
+    assertEquals {
+        expected = 0;
+        actual=sum {};
+    };
+    assertEquals {
+        expected = 6;
+        actual=sum { 1, 2, 3 };
+    };
+    print("Integer.product");
+    assertEquals {
+        expected = 1;
+        actual=product {};
+    };
+    assertEquals {
+        expected = 6;
+        actual=product { 1, 2, 3 };
+    };
+}

--- a/test-source/test/ceylon/numeric/module.ceylon
+++ b/test-source/test/ceylon/numeric/module.ceylon
@@ -1,0 +1,4 @@
+module test.ceylon.numeric "1.2.1" {
+    import ceylon.test "1.2.1";
+    import ceylon.numeric "1.2.1";
+}

--- a/test-source/test/ceylon/numeric/package.ceylon
+++ b/test-source/test/ceylon/numeric/package.ceylon
@@ -1,0 +1,1 @@
+package test.ceylon.numeric;


### PR DESCRIPTION
This replaces the code in `ceylon.numeric` with the following improvements:

- Tests, including some that did not exist in `ceylon.math`
- Bug fixes (so the tests pass)
- Compatibility with various web browsers (per MDN JS docs)
- A new function `remainder(Float, Float)`

This was discussed [here](https://github.com/ceylon/ceylon-sdk/commit/44f9a5ff43666965a6eb3a038d011ce9daddf873#commitcomment-15036857).