### PR TITLE
use latest version of ceylon.test

### DIFF
--- a/test-source/test/ceylon/buffer/module.ceylon
+++ b/test-source/test/ceylon/buffer/module.ceylon
@@ -1,5 +1,5 @@
 module test.ceylon.buffer "1.2.1" {
     shared import ceylon.buffer "1.2.1";
     shared import ceylon.collection "1.2.1";
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
 }

--- a/test-source/test/ceylon/collection/module.ceylon
+++ b/test-source/test/ceylon/collection/module.ceylon
@@ -1,4 +1,4 @@
 module test.ceylon.collection "1.2.1" {
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import ceylon.collection "1.2.1";
 }

--- a/test-source/test/ceylon/dbc/module.ceylon
+++ b/test-source/test/ceylon/dbc/module.ceylon
@@ -3,7 +3,7 @@ module test.ceylon.dbc "1.2.1" {
     import ceylon.dbc "1.2.1";
     import ceylon.interop.java "1.2.1";
     import ceylon.math "1.2.1";
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import java.base "7";
     import java.jdbc "7";
     import org.h2 "1.3.168";

--- a/test-source/test/ceylon/decimal/module.ceylon
+++ b/test-source/test/ceylon/decimal/module.ceylon
@@ -1,6 +1,6 @@
 native("jvm")
 module test.ceylon.decimal "1.2.1" {
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import ceylon.decimal "1.2.1";
     import java.base "7";
 }

--- a/test-source/test/ceylon/file/module.ceylon
+++ b/test-source/test/ceylon/file/module.ceylon
@@ -1,5 +1,5 @@
 native("jvm")
 module test.ceylon.file "1.2.1" {
     import ceylon.file "1.2.1";
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
 }

--- a/test-source/test/ceylon/html/module.ceylon
+++ b/test-source/test/ceylon/html/module.ceylon
@@ -1,7 +1,7 @@
 module test.ceylon.html "1.2.1" {
 
     import ceylon.html "1.2.1";
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import ceylon.collection "1.2.1";
 
 }

--- a/test-source/test/ceylon/interop/java/module.ceylon
+++ b/test-source/test/ceylon/interop/java/module.ceylon
@@ -2,5 +2,5 @@ native("jvm")
 module test.ceylon.interop.java "1.2.1" {
     import java.base "7";
     import ceylon.interop.java "1.2.1";
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
 }

--- a/test-source/test/ceylon/io/module.ceylon
+++ b/test-source/test/ceylon/io/module.ceylon
@@ -1,6 +1,6 @@
 native("jvm")
 module test.ceylon.io "1.2.1" {
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import ceylon.file "1.2.1";
     import ceylon.io "1.2.1";
     import ceylon.net "1.2.1";

--- a/test-source/test/ceylon/json/module.ceylon
+++ b/test-source/test/ceylon/json/module.ceylon
@@ -1,4 +1,4 @@
 module test.ceylon.json "1.2.1" {
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import ceylon.json "1.2.1";
 }

--- a/test-source/test/ceylon/locale/module.ceylon
+++ b/test-source/test/ceylon/locale/module.ceylon
@@ -1,5 +1,5 @@
 module test.ceylon.locale "1.2.1" {
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import ceylon.locale "1.2.1";
     import ceylon.time "1.2.1";
 }

--- a/test-source/test/ceylon/logging/module.ceylon
+++ b/test-source/test/ceylon/logging/module.ceylon
@@ -2,5 +2,5 @@ native("jvm")
 module test.ceylon.logging "1.2.1" {
     import java.logging "7";
     import ceylon.logging "1.2.1";
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
 }

--- a/test-source/test/ceylon/math/module.ceylon
+++ b/test-source/test/ceylon/math/module.ceylon
@@ -2,5 +2,5 @@ native("jvm")
 module test.ceylon.math "1.2.1" {
     import java.base "7";
     import ceylon.math "1.2.1";
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
 }

--- a/test-source/test/ceylon/net/module.ceylon
+++ b/test-source/test/ceylon/net/module.ceylon
@@ -1,6 +1,6 @@
 native("jvm")
 module test.ceylon.net "1.2.1" {
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import ceylon.net "1.2.1";
     import ceylon.json "1.2.1";
     import ceylon.file "1.2.1";

--- a/test-source/test/ceylon/numeric/module.ceylon
+++ b/test-source/test/ceylon/numeric/module.ceylon
@@ -1,4 +1,4 @@
 module test.ceylon.numeric "1.2.1" {
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import ceylon.numeric "1.2.1";
 }

--- a/test-source/test/ceylon/process/module.ceylon
+++ b/test-source/test/ceylon/process/module.ceylon
@@ -1,5 +1,5 @@
 native("jvm")
 module test.ceylon.process "1.2.1" {
     import ceylon.process "1.2.1";
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
 }

--- a/test-source/test/ceylon/promise/module.ceylon
+++ b/test-source/test/ceylon/promise/module.ceylon
@@ -2,6 +2,6 @@ by("Julien Viet")
 license("ASL2")
 module test.ceylon.promise "1.2.1" {
   import ceylon.promise "1.2.1";
-  import ceylon.test "1.2.1";
+  import ceylon.test "1.2.1-1";
   import ceylon.collection "1.2.1";
 }

--- a/test-source/test/ceylon/random/module.ceylon
+++ b/test-source/test/ceylon/random/module.ceylon
@@ -1,5 +1,5 @@
 module test.ceylon.random "1.2.1" {
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import ceylon.collection "1.2.1";
     shared import ceylon.random "1.2.1";
 }

--- a/test-source/test/ceylon/regex/module.ceylon
+++ b/test-source/test/ceylon/regex/module.ceylon
@@ -1,4 +1,4 @@
 module test.ceylon.regex "1.2.1" {
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import ceylon.regex "1.2.1";
 }

--- a/test-source/test/ceylon/time/module.ceylon
+++ b/test-source/test/ceylon/time/module.ceylon
@@ -1,6 +1,6 @@
 "Ceylon Time SDK tests"
 module test.ceylon.time "1.2.1" {
     import ceylon.time "1.2.1";
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import ceylon.collection "1.2.1";
 }

--- a/test-source/test/ceylon/transaction/module.ceylon
+++ b/test-source/test/ceylon/transaction/module.ceylon
@@ -1,6 +1,6 @@
 native("jvm")
 module test.ceylon.transaction "1.2.1" {
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     // NB need to use shared import to manually enlist resources
     shared import ceylon.transaction "1.2.1";
 

--- a/test-source/test/ceylon/unicode/module.ceylon
+++ b/test-source/test/ceylon/unicode/module.ceylon
@@ -1,5 +1,5 @@
 native("jvm")
 module test.ceylon.unicode "1.2.1" {
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import ceylon.unicode "1.2.1";
 }

--- a/test-source/test/ceylon/whole/common/module.ceylon
+++ b/test-source/test/ceylon/whole/common/module.ceylon
@@ -1,5 +1,5 @@
 module test.ceylon.whole.common "1.2.1" {
     import ceylon.collection "1.2.1"; // to make compile-js work
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import ceylon.whole "1.2.1";
 }

--- a/test-source/test/ceylon/whole/jvm/module.ceylon
+++ b/test-source/test/ceylon/whole/jvm/module.ceylon
@@ -1,7 +1,7 @@
 native("jvm")
 module test.ceylon.whole.jvm "1.2.1" {
     import java.base "7";
-    import ceylon.test "1.2.1";
+    import ceylon.test "1.2.1-1";
     import ceylon.whole "1.2.1";
     import ceylon.random "1.2.1";
 }


### PR DESCRIPTION
Using Eclipse to work on ceylon-sdk is nearly impossible without this patch.