### PR TITLE
Fix HashSet rehashing issue

### DIFF
--- a/source/ceylon/collection/HashSet.ceylon
+++ b/source/ceylon/collection/HashSet.ceylon
@@ -206,10 +206,6 @@ shared class HashSet<Element>
                         newStore);
                     variable value newBucket
                             = newStore[newIndex];
-                    while (exists newCell
-                                = newBucket?.rest) {
-                        newBucket = newCell;
-                    }
                     cell.rest = newBucket;
                     newStore.set(newIndex, cell);
                 }

--- a/source/ceylon/collection/HashSet.ceylon
+++ b/source/ceylon/collection/HashSet.ceylon
@@ -204,8 +204,7 @@ shared class HashSet<Element>
                     Integer newIndex
                             = storeIndex(cell.element,
                         newStore);
-                    variable value newBucket
-                            = newStore[newIndex];
+                    value newBucket = newStore[newIndex];
                     cell.rest = newBucket;
                     newStore.set(newIndex, cell);
                 }

--- a/test-source/test/ceylon/collection/hashSet.ceylon
+++ b/test-source/test/ceylon/collection/hashSet.ceylon
@@ -10,10 +10,11 @@ import ceylon.test {
 
 shared class HashSetTest() satisfies MutableSetTests & InsertionOrderIterableTests {
 
-    shared actual MutableSet<String> createSet({String*} strings) => HashSet { elements = strings; };
+    shared actual MutableSet<T> createSet<T>({T*} elts) given T satisfies Comparable<T>
+            => HashSet { elements = elts; };
 
-    createCategory = createSet;
-    createIterable = createSet;
+    createCategory = createSet<String>;
+    createIterable = createSet<String>;
 
     test shared void elementsAreKeptInOrder() {
         value set = HashSet { "A", "B", "C" };
@@ -24,7 +25,7 @@ shared class HashSetTest() satisfies MutableSetTests & InsertionOrderIterableTes
     }
     
     test shared void elementsAreRemovedFromLinkedList(){
-        value set = createSet{};
+        value set = createSet<String>{};
         set.add("a");
         set.add("b");
         set.remove("a");
@@ -35,9 +36,10 @@ shared class HashSetTest() satisfies MutableSetTests & InsertionOrderIterableTes
 
 shared class UnlinkedHashSetTest() satisfies MutableSetTests & HashOrderIterableTests {
 
-    shared actual MutableSet<String> createSet({String*} strings) => HashSet { stability = unlinked; elements = strings; };
+    shared actual MutableSet<T> createSet<T>({T*} elts) given T satisfies Object
+            => HashSet { stability = unlinked; elements = elts; };
 
-    createCategory = createSet;
-    createIterable = createSet;
+    createCategory = createSet<String>;
+    createIterable = createSet<String>;
 
 }

--- a/test-source/test/ceylon/collection/mutableSet.ceylon
+++ b/test-source/test/ceylon/collection/mutableSet.ceylon
@@ -10,10 +10,67 @@ import ceylon.test {
 
 shared interface MutableSetTests satisfies SetTests {
 
-    shared actual formal MutableSet<String> createSet({String*} strings);
+    shared actual formal MutableSet<T> createSet<T>({T*} elements) given T satisfies Comparable<T>;
+
+    test shared void doPoorHashTests() {
+        class PoorHash(Integer h, Integer id) satisfies Comparable<PoorHash>{
+            shared actual Integer hash {
+                return h;
+            }
+            shared actual Boolean equals(Object that) {
+                if (is PoorHash that) {
+                    return id == that.id;
+                }
+                return false;
+            }
+            shared actual Comparison compare(PoorHash other) => this.id <=> other.id;
+        }
+        value set = createSet<PoorHash> {};
+        set.add(PoorHash(1, 1));
+        set.add(PoorHash(1, 2));
+        set.add(PoorHash(1, 3));
+        set.add(PoorHash(1, 4));
+
+        set.add(PoorHash(1, 5));
+        set.add(PoorHash(1, 6));
+        set.add(PoorHash(1, 7));
+        set.add(PoorHash(1, 8));
+
+        set.add(PoorHash(1, 9));
+        set.add(PoorHash(1, 10));
+        set.add(PoorHash(1, 11));
+        set.add(PoorHash(1, 12));
+
+        set.add(PoorHash(1, 13));
+        set.add(PoorHash(1, 14));
+        set.add(PoorHash(1 ,15));
+        set.add(PoorHash(1, 16));
+        assertEquals(set.size, 16);
+
+        set.add(PoorHash(1, 1));
+        set.add(PoorHash(1, 2));
+        set.add(PoorHash(1, 3));
+        set.add(PoorHash(1, 4));
+
+        set.add(PoorHash(1, 5));
+        set.add(PoorHash(1, 6));
+        set.add(PoorHash(1, 7));
+        set.add(PoorHash(1, 8));
+
+        set.add(PoorHash(1, 9));
+        set.add(PoorHash(1, 10));
+        set.add(PoorHash(1, 11));
+        set.add(PoorHash(1, 12));
+
+        set.add(PoorHash(1, 13));
+        set.add(PoorHash(1, 14));
+        set.add(PoorHash(1 ,15));
+        set.add(PoorHash(1, 16));
+        assertEquals(set.size, 16);
+    }
 
     test shared void doSetTests() {
-        value set = createSet {};
+        value set = createSet<String> {};
         assertEquals("{}", set.string);
         assertEquals(0, set.size);
         assertEquals(true, set.add("fu"));

--- a/test-source/test/ceylon/collection/set.ceylon
+++ b/test-source/test/ceylon/collection/set.ceylon
@@ -6,7 +6,7 @@ import ceylon.test {
 }
 
 shared interface SetTests satisfies IterableTests {
-    shared formal Set<String> createSet({String*} strings);
+    shared formal Set<T> createSet<T>({T*} elements) given T satisfies Comparable<T>;
 
     test shared void testEquals() {
         {[{String*}, [String*]]+} positiveEqualExamples = {

--- a/test-source/test/ceylon/collection/treeSet.ceylon
+++ b/test-source/test/ceylon/collection/treeSet.ceylon
@@ -11,13 +11,14 @@ import ceylon.test {
 
 shared class TreeSetTest() satisfies MutableSetTests & NaturalOrderIterableTests {
 
-    shared actual MutableSet<String> createSet({String*} strings) => TreeSet {
-        function compare (String x, String y) => x <=> y;
-        elements = strings;
+    shared actual MutableSet<T> createSet<T>({T*} elts) given T satisfies Comparable<T>
+             => TreeSet {
+        function compare (T x, T y) => x <=> y;
+        elements = elts;
     };
 
-    createCategory = createSet;
-    createIterable = createSet;
+    createCategory = createSet<String>;
+    createIterable = createSet<String>;
     
     test shared void elementsAreKeptInOrder() {
         value set = createSet { "A", "B", "C" };


### PR DESCRIPTION
During rehasing, only the last 2 cell would be preserved per bucket in the new store, leading to elements disappearing during rehashing.
The old code finds the the last cell in the bucket and links it to the new cell.
Since order in the buckets does not matter (even when `stability == linked`), remove this search and simply insert the new cell at the head of the bucket.

The tests changes are more complicated than i'd like because i want to control hash collisions which is not so easy with strings.