### PR TITLE
ceylon.io: Add failback callback to async connect

### DIFF
--- a/source/ceylon/io/Selector.ceylon
+++ b/source/ceylon/io/Selector.ceylon
@@ -82,11 +82,13 @@ shared sealed interface Selector {
     "Registers a `connect` listener on the given 
      [[SocketConnector]]. The given [[callback function|connect]] 
      will be invoked by [[process]] as soon as the given 
-     [[socketConnector]] can be connected without blocking.
+     [[socketConnector]] can be connected without blocking. 
+     If [[callback function|failureCallback]] is given, it 
+     is called if the connection attempt fails.
      
-     The callback function will only be invoked at most once."
-    shared formal void addConnectListener(SocketConnector socketConnector, 
-        void connect(Socket s));
+     Only either callback function will be invoked, exactly once."
+    shared formal void addConnectListener(SocketConnector socketConnector,
+        void connect(Socket s), Anything(Exception)? failureCallback = null);
 
     "Registers an `accept` listener on the given 
      [[ServerSocket]]. The given [[callback function|accept]] 

--- a/source/ceylon/io/SocketConnector.ceylon
+++ b/source/ceylon/io/SocketConnector.ceylon
@@ -23,7 +23,7 @@ shared sealed interface SocketConnector{
      socket is connected."
     see(`interface Selector`)
     shared formal void connectAsync(Selector selector, 
-        void connect(Socket socket));
+        void connect(Socket socket), Anything(Exception)? connectFailure = null);
 
     "Closes this socket connector."
     shared formal void close();

--- a/source/ceylon/io/impl/SelectorImpl.ceylon
+++ b/source/ceylon/io/impl/SelectorImpl.ceylon
@@ -79,7 +79,7 @@ shared class SelectorImpl()
     }
 
     shared actual void addConnectListener(SocketConnector connector, 
-        void callback(Socket s), Anything(Exception)? failureCallback = null) {
+        void callback(Socket s), Anything(Exception)? failureCallback) {
         assert(is SocketConnectorImpl connector);
         if(exists javaKey = connector.channel.keyFor(javaSelector)) {
             assert(exists key = map[javaKey]);

--- a/source/ceylon/io/impl/SelectorImpl.ceylon
+++ b/source/ceylon/io/impl/SelectorImpl.ceylon
@@ -23,12 +23,13 @@ import java.nio.channels {
 
 class Key(socket = null, onRead = null, onWrite = null, 
           connector = null, onConnect = null,
-          acceptor = null, onAccept = null) {
+          acceptor = null, onAccept = null, onConnectFailure = null) {
     shared variable Callable<Boolean, [FileDescriptor]>? onRead;
     shared variable Callable<Boolean, [FileDescriptor]>? onWrite;
     shared variable FileDescriptor? socket;
     
     shared variable Callable<Anything, [Socket]>? onConnect;
+    shared variable Callable<Anything, [Exception]>? onConnectFailure;
     shared variable SocketConnectorImpl? connector;
     
     shared variable Callable<Boolean, [Socket]>? onAccept;
@@ -78,18 +79,19 @@ shared class SelectorImpl()
     }
 
     shared actual void addConnectListener(SocketConnector connector, 
-        void callback(Socket s)) {
+        void callback(Socket s), Anything(Exception)? failureCallback = null) {
         assert(is SocketConnectorImpl connector);
         if(exists javaKey = connector.channel.keyFor(javaSelector)) {
             assert(exists key = map[javaKey]);
             // update our key
             key.onConnect = callback;
+            key.onConnectFailure = failureCallback;
             key.connector = connector;
             connector.interestOps(javaKey, 
                 javaKey.interestOps().or(javaConnectOp));
         }else{
             // new key
-            value key = Key { onConnect = callback; connector = connector; };
+            value key = Key { onConnect = callback; onConnectFailure = failureCallback; connector = connector; };
             value newJavaKey = 
                     connector.register(javaSelector, javaConnectOp, key);
             map.put(newJavaKey, key);
@@ -186,8 +188,16 @@ shared class SelectorImpl()
         if(selectedKey.valid && selectedKey.connectable) {
             assert(exists connector = key.connector,
                    exists callback = key.onConnect);
-            // FIXME: check
-            connector.channel.finishConnect();
+            try {
+                connector.channel.finishConnect();
+            } catch(e) {
+                if (exists failureCallback = key.onConnectFailure) {
+                    failureCallback(e);
+                }
+                selectedKey.cancel();
+                map.remove(selectedKey);
+                return;
+            }
             // create a new socket
             value socket = connector.createSocket();
             callback(socket);

--- a/source/ceylon/io/impl/SocketConnectorImpl.ceylon
+++ b/source/ceylon/io/impl/SocketConnectorImpl.ceylon
@@ -32,7 +32,7 @@ shared class SocketConnectorImpl(SocketAddress address)
     shared default Socket createSocket() => SocketImpl(channel);
     
     shared actual void connectAsync(Selector selector, 
-        void connect(Socket socket), Anything(Exception)? connectFailure = null) {
+        void connect(Socket socket), Anything(Exception)? connectFailure) {
         channel.configureBlocking(false);
         channel.connect(InetSocketAddress(address.address, 
             address.port));

--- a/source/ceylon/io/impl/SocketConnectorImpl.ceylon
+++ b/source/ceylon/io/impl/SocketConnectorImpl.ceylon
@@ -32,11 +32,11 @@ shared class SocketConnectorImpl(SocketAddress address)
     shared default Socket createSocket() => SocketImpl(channel);
     
     shared actual void connectAsync(Selector selector, 
-        void connect(Socket socket)) {
+        void connect(Socket socket), Anything(Exception)? connectFailure = null) {
         channel.configureBlocking(false);
         channel.connect(InetSocketAddress(address.address, 
             address.port));
-        selector.addConnectListener(this, connect);
+        selector.addConnectListener(this, connect, connectFailure);
     }
     
     shared actual void close() => channel.close();

--- a/test-source/test/ceylon/io/testSockets.ceylon
+++ b/test-source/test/ceylon/io/testSockets.ceylon
@@ -4,6 +4,7 @@ import ceylon.io {
     newSelector,
     SocketConnector,
     SocketAddress,
+    newSocketConnector,
     newSslSocketConnector
 }
 import ceylon.io.buffer {
@@ -14,6 +15,13 @@ import ceylon.io.charset {
 }
 import ceylon.net.uri {
     parse
+}
+import ceylon.test {
+    assertEquals,
+    test
+}
+import ceylon.collection {
+    ArrayList
 }
 
 void readResponse(Socket socket) {
@@ -141,4 +149,26 @@ void testGrrr(){
     //readAndWriteAsync(request, socket);
 
     socket.close();
+}
+
+test void testConnectFailure() {
+    value connectSuccessQueue = ArrayList<Socket>();
+    value connectFailureQueue = ArrayList<Exception>();
+    value connector = newSocketConnector(SocketAddress("127.0.0.1", 12));
+    Selector select = newSelector();
+    connector.connectAsync {
+        selector = select;
+        void connect(Socket socket) {
+            connectSuccessQueue.add(socket);
+        }
+        void connectFailure(Exception exception) {
+            connectFailureQueue.add(exception);
+        }
+    };
+    // run the event loop
+    select.process();
+    connector.close();
+    assertEquals(0, connectSuccessQueue.size);
+    assertEquals(1, connectFailureQueue.size);
+    assertEquals("Connection refused", connectFailureQueue[0]?.message);
 }


### PR DESCRIPTION
When asynchronously connecting a socket, any errors were silently discarded. There was even a FIXME in the code to handle the situation correctly. Fixme now implemented (hopefully correctly) and also the possibility to specify a failure callback when connecting asynchronously. The callback is specified through an argument that defaults to null so old code should work fine without changes, but probably needing a recompile.

I created this against 1.2.1-fixes but it I guess it should be applicable to any branch.