### PR TITLE
Fix ceylon.regex/split() JS implementation. Add unit test.

### DIFF
--- a/source/ceylon/regex/regexpjs.ceylon
+++ b/source/ceylon/regex/regexpjs.ceylon
@@ -72,7 +72,7 @@ class RegexJavascript(expression, global = false, ignoreCase = false, multiLine 
         variable String[] result  = [];
         dynamic i = input;
         dynamic {
-            dynamic y = if (limit >= 0) then i.split(ex, l) else i.split(ex);
+            dynamic y = if (limit >= 0) then i.split(ex, limit) else i.split(ex);
             for (String s in y) {
                 result = result.append([s]);
             }

--- a/test-source/test/ceylon/regex/test.ceylon
+++ b/test-source/test/ceylon/regex/test.ceylon
@@ -153,6 +153,13 @@ shared void testSplit() {
 }
 
 test
+shared void testSplitWithLimit() {
+    value result = regex{expression=" "; global=true;}.split(input,3);
+    print(result);
+    assertEquals(result, ["De", "aap", "is"]);
+}
+
+test
 shared void testTest() {
     assertTrue(regex("a+p").test(input));
     assertTrue(regex{expression="^de.*RD!$"; ignoreCase=true;}.test(input));
@@ -184,6 +191,7 @@ shared void runAll() {
     testReplaceGlobal();
     testReplaceError();
     testSplit();
+    testSplitWithLimit();
     testTest();
     testTestQuoted();
 }


### PR DESCRIPTION
The "limit" argument was misspelled inside a dynamic block and caused runtime exception when the argument had non-default value.