### PR TITLE
fix unlinked HashMap.first and last, optimize

### DIFF
--- a/source/ceylon/collection/HashMap.ceylon
+++ b/source/ceylon/collection/HashMap.ceylon
@@ -430,14 +430,14 @@ shared class HashMap<Key, Item>
     shared actual <Key->Item>? first 
             => if (stability==linked) 
                 then head?.element 
-                else store[0]?.element;
+                else store.coalesced.first?.element;
     
     shared actual <Key->Item>? last {
         if (stability == linked) {
             return tip?.element;
         }
         else {
-            variable value bucket = store.last;
+            variable value bucket = store.reversed.coalesced.first;
             while (exists cell = bucket?.rest) {
                 bucket = cell;
             }

--- a/source/ceylon/collection/HashSet.ceylon
+++ b/source/ceylon/collection/HashSet.ceylon
@@ -460,7 +460,7 @@ shared class HashSet<Element>
             return tip?.element;
         }
         else {
-            variable value bucket = store.coalesced.last;
+            variable value bucket = store.reversed.coalesced.first;
             while (exists cell = bucket?.rest) {
                 bucket = cell;
             }

--- a/test-source/test/ceylon/collection/map.ceylon
+++ b/test-source/test/ceylon/collection/map.ceylon
@@ -48,6 +48,18 @@ void doTestMap(MutableMap<String,String> map) {
     assertTrue(clone.definesEvery((71..100).map(toString)));
     assertFalse(clone.definesAny((60..70).map(toString)));
     assertTrue(map.definesEvery((11..100).map(toString)));
+    
+    // first and last
+    map.clear();
+    assertNull(map.first);
+    assertNull(map.last);
+    map.put("a", "a");
+    assertEquals(map.first?.key, "a");
+    assertEquals(map.last?.key, "a");
+    map.put("1", "1");
+    assertNotNull(map.first);
+    assertNotNull(map.last);
+    assertNotEquals(map.first, map.last);
 }
 
 shared test void testMap(){
@@ -56,6 +68,7 @@ shared test void testMap(){
     treeMap.assertInvariants();
     treeMap.clone().assertInvariants();
     doTestMap(HashMap<String,String>());
+    doTestMap(HashMap<String,String> { stability = unlinked; });
 }
 
 shared test void testMapEquality() {


### PR DESCRIPTION
The first at last elements of the store array may be null, even for non empty maps.