### PR TITLE
optimize, fix, and test interop list remove methods

### DIFF
--- a/source/ceylon/interop/java/CeylonMutableList.ceylon
+++ b/source/ceylon/interop/java/CeylonMutableList.ceylon
@@ -49,9 +49,12 @@ shared class CeylonMutableList<Element>(JList<Element> list)
     
     shared actual Element? findAndRemoveFirst(
         Boolean selecting(Element element)) {
-        for (i in 0:size) {
-            if (selecting(list.get(i))) {
-                return list.remove(i);
+        value it = list.iterator();
+        while (it.hasNext()) {
+            value item = it.next();
+            if (selecting(item)) {
+                it.remove();
+                return item;
             }
         }
         return null;
@@ -59,9 +62,12 @@ shared class CeylonMutableList<Element>(JList<Element> list)
     
     shared actual Element? findAndRemoveLast(
         Boolean selecting(Element element)) {
-        for (i in (0:size).reversed) {
-            if (selecting(list.get(i))) {
-                return list.remove(i);
+        value it = list.listIterator(list.size());
+        while (it.hasPrevious()) {
+            value item = it.previous();
+            if (selecting(item)) {
+                it.remove();
+                return item;
             }
         }
         return null;
@@ -70,9 +76,10 @@ shared class CeylonMutableList<Element>(JList<Element> list)
     shared actual Integer removeWhere(
         Boolean selecting(Element element)) {
         variable Integer count = 0;
-        for (i in 0:size) {
-            if (selecting(list.get(i))) {
-                list.remove(i);
+        value it = list.iterator();
+        while (it.hasNext()) {
+            if (selecting(it.next())) {
+                it.remove();
                 count++;
             }
         }

--- a/test-source/test/ceylon/interop/java/interopTests.ceylon
+++ b/test-source/test/ceylon/interop/java/interopTests.ceylon
@@ -169,3 +169,45 @@ test void ceylonRunnableThread() {
     t2.join();
     assertEquals { expected = 2; actual = i; };
 }
+
+test void mutableListRemoveWhere() {
+    value javaList = ArrayList<Integer>(JavaCollection(1..10));
+    value ceylonList = CeylonMutableList(javaList);
+
+    assertEquals(ceylonList.removeWhere(Integer.even), 5);
+    assertEquals(ceylonList, [1, 3, 5, 7, 9]);
+
+    assertEquals(ceylonList.removeWhere((i) => false), 0);
+    assertEquals(ceylonList, [1, 3, 5, 7, 9]);
+
+    javaList.clear();
+    assertEquals(ceylonList.removeWhere((i) => true), 0);
+}
+
+test void mutableListRemoveFirst() {
+    value javaList = ArrayList<Integer>(JavaCollection(1..10));
+    value ceylonList = CeylonMutableList(javaList);
+
+    assertEquals(ceylonList.findAndRemoveFirst(Integer.even), 2);
+    assertEquals(ceylonList, [1, *(3..10)]);
+
+    assertEquals(ceylonList.findAndRemoveFirst((i) => false), null);
+    assertEquals(ceylonList, [1, *(3..10)]);
+
+    javaList.clear();
+    assertEquals(ceylonList.findAndRemoveFirst((i) => true), null);
+}
+
+test void mutableListRemoveLast() {
+    value javaList = ArrayList<Integer>(JavaCollection(1..5));
+    value ceylonList = CeylonMutableList(javaList);
+
+    assertEquals(ceylonList.findAndRemoveLast(Integer.even), 4);
+    assertEquals(ceylonList, [1, 2, 3, 5]);
+
+    assertEquals(ceylonList.findAndRemoveLast((i) => false), null);
+    assertEquals(ceylonList, [1, 2, 3, 5]);
+
+    javaList.clear();
+    assertEquals(ceylonList.findAndRemoveLast((i) => true), null);
+}


### PR DESCRIPTION
- removeWhere() had an off-by-n indexing problem after n-removals
- using Java iterators improves performance for non-random-access lists