### PR TITLE
Fix for JSON parser being unable to handle some floats.

### DIFF
--- a/source/ceylon/json/parse.ceylon
+++ b/source/ceylon/json/parse.ceylon
@@ -102,17 +102,17 @@ shared Integer|Float parseNumber(Tokenizer tokenizer){
     Integer wholePart = parseDigits(tokenizer);
     
     if(tokenizer.hasMore && tokenizer.check('.')){
-        Integer start = tokenizer.position;
-        Integer fractionPart = parseDigits(tokenizer);
-        Integer digits = tokenizer.position - start;
-        Float float = wholePart.float + 
-                (fractionPart.float / (10 ^ digits).float);
-        Float signedFloat = negative then -float else float;
-        Integer? exp1 = parseExponent(tokenizer);
-        if(exists exp1){
-            return signedFloat * (10.float ^ exp1.float);
-        }
-        return signedFloat;
+        // Parsing floats is tricky if you want to get all the corner cases like very small
+        // or very large floats, and get every single digit correct. Rather than re-implement
+        // we will build a string then use the built-in native parseFloat() function.
+        Integer digitsAfterDecimal = parseDigits(tokenizer);
+        Integer? exponent  = parseExponent(tokenizer);
+        String exponentAsString = if (exists exponent) then "e``exponent``" else "";
+        String negativeSign = negative then "-" else "";
+        String floatAsString = "``negativeSign````wholePart``.``digitsAfterDecimal````exponentAsString``";
+        Float? float = parseFloat(floatAsString);
+        assert(exists float); // the structure above guarantees it will be a valid float
+        return float;
     }
     
     Integer signedInteger = 

--- a/test-source/test/ceylon/json/parse.ceylon
+++ b/test-source/test/ceylon/json/parse.ceylon
@@ -835,6 +835,9 @@ shared test void testParse() {
     } catch (ParseException p) {
     }
     
+    assert(is Float n3 = parse("0.6666666666666666"));
+    assertEquals(0.6666666666666666, n3);
+    
     assert(is Object o1 = parse("{}"));
     assertEquals(0, o1.size);
     try {


### PR DESCRIPTION
I encountered this problem: A JSON file was created with a value in it like 0.6666666666666666. This results in an exception because some of the intermediate values cannot be stored as floats. I propose that the best solution for reliably parsing floats that works in ALL cases is to use existing code for parsing floats. I think that the attached code will fix this (plus it adds a test case to illustrate the original error).