### PR TITLE
Add wrapper_type module to Ceylon SDK.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -79,6 +79,7 @@
             <module name="ceylon.transaction"/>
             <module name="ceylon.unicode"/>
             <module name="ceylon.whole"/>
+            <module name="ceylon.wrapper_type"/>
             <module name="com.redhat.ceylon.war"/>
         </moduleset>
 
@@ -97,6 +98,7 @@
             <module name="ceylon.test"/>
             <module name="ceylon.time"/>
             <module name="ceylon.whole"/>
+            <module name="ceylon.wrapper_type"/>
         </moduleset>
 	
         <moduleset id="modules.sdk.doc">
@@ -124,6 +126,7 @@
             <module name="ceylon.transaction"/>
             <module name="ceylon.unicode"/>
             <module name="ceylon.whole"/>
+            <module name="ceylon.wrapper_type"/>
             <module name="com.redhat.ceylon.war"/>
         </moduleset>
 
@@ -152,6 +155,7 @@
             <module name="test.ceylon.transaction"/>
             <module name="test.ceylon.whole.common"/>
             <module name="test.ceylon.whole.jvm"/>
+            <module name="test.ceylon.wrapper_type"/>
         </moduleset>
 
         <moduleset id="modules.test.js">
@@ -167,6 +171,7 @@
             <module name="test.ceylon.locale"/>
             <module name="test.ceylon.regex"/>
             <module name="test.ceylon.whole.common"/>
+            <module name="test.ceylon.wrapper_type"/>
         </moduleset>
     </target>
     

--- a/source/ceylon/wrapper_type/WrappedBoolean.ceylon
+++ b/source/ceylon/wrapper_type/WrappedBoolean.ceylon
@@ -1,0 +1,3 @@
+"Subclass of [[WrapperType]] for [[Boolean]]s."
+shared abstract class WrappedBoolean(Boolean baseValue) 
+        extends WrapperType<Boolean>(baseValue) {}

--- a/source/ceylon/wrapper_type/WrappedByte.ceylon
+++ b/source/ceylon/wrapper_type/WrappedByte.ceylon
@@ -1,0 +1,3 @@
+"Subclass of [[WrapperType]] for [[Byte]]s."
+shared abstract class WrappedByte(Byte baseValue)
+        extends WrapperType<Byte>(baseValue) {}

--- a/source/ceylon/wrapper_type/WrappedFloat.ceylon
+++ b/source/ceylon/wrapper_type/WrappedFloat.ceylon
@@ -1,0 +1,3 @@
+"Subclass of [[WrapperType]] for [[Float]]s."
+shared abstract class WrappedFloat(Float baseValue)
+        extends WrapperType<Float>(baseValue) {}

--- a/source/ceylon/wrapper_type/WrappedInteger.ceylon
+++ b/source/ceylon/wrapper_type/WrappedInteger.ceylon
@@ -1,0 +1,3 @@
+"Subclass of [[WrapperType]] for [[Integer]]s."
+shared abstract class WrappedInteger(Integer baseValue)
+        extends WrapperType<Integer>(baseValue) {}

--- a/source/ceylon/wrapper_type/WrappedString.ceylon
+++ b/source/ceylon/wrapper_type/WrappedString.ceylon
@@ -1,0 +1,18 @@
+"Subclass of [[WrappedTypedComparable]] for [[String]]s.  Supports operations on [[List]]s of [[Character]]s."
+shared abstract class WrappedString(String baseValue)
+        extends WrappedTypedComparable<String>(baseValue)
+        satisfies List<Character> {
+
+    shared actual Boolean equals(Object other) =>
+        (super of WrapperType<String>).equals(other);
+
+    shared actual Integer hash => (super of WrapperType<String>).hash;
+
+    shared actual String string => (super of WrapperType<String>).string;
+
+    shared actual String span(Integer from, Integer to) => baseValue.span(from, to);
+
+    shared actual Integer? lastIndex => baseValue.lastIndex;
+
+    shared actual Character? getFromFirst(Integer index) => baseValue.getFromFirst(index);
+}

--- a/source/ceylon/wrapper_type/WrappedTypedComparable.ceylon
+++ b/source/ceylon/wrapper_type/WrappedTypedComparable.ceylon
@@ -1,0 +1,11 @@
+"A [[WrapperType]] variant that supports subclasses that are [[Comparable]] and its associated attributes and functions.
+ An example is [[WrappedString]].
+"
+shared abstract class WrappedTypedComparable<ValueType>(ValueType baseValue)
+        extends WrapperType<ValueType>(baseValue)
+        satisfies Comparable<WrappedTypedComparable<ValueType>>
+        given ValueType satisfies Comparable<ValueType> {
+
+    shared actual Comparison compare(WrappedTypedComparable<ValueType> other)
+            => baseValue.compare(other.baseValue);
+}

--- a/source/ceylon/wrapper_type/WrapperType.ceylon
+++ b/source/ceylon/wrapper_type/WrapperType.ceylon
@@ -18,7 +18,7 @@ shared abstract class WrapperType<ValueType>("Underlying value wrapped by the [[
     "[[Type]] associated with the [[WrapperType]]"
     shared Type<> classType => type(this);
 
-    "Display name of the type (ex WrappedString is \"WrappedString\""
+    "Display name of the type (ex WrappedString is \"WrappedString\")"
     shared String name => displayNameForType(classType);
 
     shared actual default Boolean equals(Object other) {

--- a/source/ceylon/wrapper_type/WrapperType.ceylon
+++ b/source/ceylon/wrapper_type/WrapperType.ceylon
@@ -1,0 +1,42 @@
+import ceylon.language.meta {
+    type
+}
+import ceylon.language.meta.model {
+    Type
+}
+
+"Root of the hierarchy of wrapper types.  Allows for numerous possible subclasses to act as wrapper types for commonly
+ used types to add better typing context.  See [[WrappedTypedComparable]] and [[WrappedInteger]] for examples of subclasses.
+ For example, a subclass of [[WrappedInteger]] can declare a ReferenceNumber class as a subclass that will only be
+ comparable to other ReferenceNumber classes, otherwise identical base values of different [[WrappedInteger]] subclasses
+ will not be considered equal according to equals().
+ "
+shared abstract class WrapperType<ValueType>("Underlying value wrapped by the [[WrapperType]]"
+                                            shared ValueType baseValue)
+        given ValueType satisfies Object {
+
+    "[[Type]] associated with the [[WrapperType]]"
+    shared Type<> classType => type(this);
+
+    "Display name of the type (ex WrappedString is \"WrappedString\""
+    shared String name => displayNameForType(classType);
+
+    shared actual default Boolean equals(Object other) {
+        if (is WrapperType<ValueType> other) {
+            if (classType== other.classType) {
+                return baseValue == other.baseValue;
+            }
+        }
+
+        return false;
+    }
+
+    shared actual default Integer hash {
+        value prime = 31;
+        value result = 1;
+
+        return prime * result + baseValue.hash;
+    }
+
+    shared actual default String string => "``name``: baseValue->``baseValue``";
+}

--- a/source/ceylon/wrapper_type/displayNameForType.ceylon
+++ b/source/ceylon/wrapper_type/displayNameForType.ceylon
@@ -1,0 +1,27 @@
+import ceylon.language.meta.model {
+    Type,
+    ClassOrInterface,
+    UnionType,
+    IntersectionType,
+    nothingType
+}
+
+"For any given [[Type]], return the name of its [[ceylon.language.meta.declaration::ClassOrInterfaceDeclaration]]
+ irrespective of whether it's a [[ClassOrInterface]], [[UnionType]], [[IntersectionType]], or [[nothingType]]"
+throws(`class AssertionError`, "All variants of [[Type]] are not accounted for by this method.")
+shared String displayNameForType<in MyType>(Type<MyType> theType) {
+    if (is ClassOrInterface<MyType> theType) {
+        return theType.declaration.name;
+    } else if (is UnionType<MyType> theType) {
+        return "|".join(theType.caseTypes.map(displayNameForType<Anything>));
+    } else if (is IntersectionType<MyType> theType) {
+        return "&".join(theType.satisfiedTypes.map(displayNameForType<Anything>));
+    } else if (nothingType == theType) {
+        return "nothingType";
+    }
+
+    // This should never happen because the above if/else if block should exhaust all possible
+    // subtypes/instances of [[Type]].  However, if Type is extended in the future, this could
+    // be an issue.
+    throw AssertionError("Did not account for this instance of Type: ``theType``");
+}

--- a/source/ceylon/wrapper_type/module.ceylon
+++ b/source/ceylon/wrapper_type/module.ceylon
@@ -1,0 +1,49 @@
+"Wrapper types for commonly used types to add unique typing.  Example, in contexts where several
+ Integer variables are used for different concepts such as AccountNumber, ReferenceNumber, etc.  This
+ adds more safety than raw [[Integer]]s or [[String]]s, etc.
+
+ Examples:
+       class AccountNumber(Integer baseValue) extends WrappedInteger(baseValue) {}
+       class ReferenceNumber(Integer baseValue) extends WrappedInteger(baseValue) {}
+
+       value accountNum1 = AccountNumber(1);
+       value accountNum2 = AccountNumber(2);
+
+       value refNum1 = ReferenceNumber(1);
+       value refNum2 = ReferenceNumber(2);
+
+       assertFalse(accountNum1 == accountNum2);
+       assertFalse(accountNum1 == referenceNum1);
+       assertFalse(referenceNum2 == accountNum2);
+
+ Any time one wishes to simply wrap around a given custom class without supporting comparison, one
+ should simply extends [[WrapperType]].  If one wishes to make use of [[Comparable]], then one should
+ extends [[WrappedTypedComparable]].
+
+ An example of [[WrappedTypedComparable]] is [[WrappedString]]
+
+ In addition, it is possible to write a custom wrapper for a custom class.
+
+ Example:
+        class Widget(shared String name) {}
+        class WrappedWidget extends WrapperType<Widget>(baseValue) {}
+
+ Also, there is a displayNameForType function that will output the declaration name for a type for all four possibilities,
+ recursively if necessary:
+
+ - [[ceylon.language.meta.model::ClassOrInterface]]
+ - [[ceylon.language.meta.model::UnionType]]
+ - [[ceylon.language.meta.model::IntersectionType]]
+ - [[ceylon.language.meta.model::nothingType]]
+
+        displayNameForType(`String`)
+
+ &gt; <b>String</b>
+
+        displayNameForType(`String|Integer`)
+
+ &gt; <b>String|Integer</b>
+"
+
+by("Luke deGruchy")
+module ceylon.wrapper_type "1.2.3" {}

--- a/source/ceylon/wrapper_type/package.ceylon
+++ b/source/ceylon/wrapper_type/package.ceylon
@@ -1,0 +1,1 @@
+shared package ceylon.wrapper_type;

--- a/test-source/test/ceylon/wrapper_type/TestWrappedInteger.ceylon
+++ b/test-source/test/ceylon/wrapper_type/TestWrappedInteger.ceylon
@@ -1,0 +1,27 @@
+import ceylon.test {
+    test,
+    assertEquals,
+    assertNotEquals
+}
+import ceylon.wrapper_type {
+    WrappedInteger
+}
+
+test
+void testTypedInteger() {
+    class MyInteger(Integer baseValue) extends WrappedInteger(baseValue) {}
+    class MyInteger2(Integer baseValue) extends WrappedInteger(baseValue) {}
+
+    value myInteger59First = MyInteger(59);
+    value myInteger59Second = MyInteger(59);
+    value myInteger62 = MyInteger(62);
+
+    assertEquals(myInteger59First.baseValue, 59);
+    assertEquals(myInteger59First.name, "MyInteger");
+    assertEquals(myInteger59First, myInteger59Second);
+    assertNotEquals(myInteger59First, myInteger62);
+
+    value myInteger2 = MyInteger2(59);
+
+    assertNotEquals(myInteger59First, myInteger2);
+}

--- a/test-source/test/ceylon/wrapper_type/TestWrappedString.ceylon
+++ b/test-source/test/ceylon/wrapper_type/TestWrappedString.ceylon
@@ -1,0 +1,43 @@
+import ceylon.test {
+    test,
+    assertEquals,
+    assertNotEquals,
+    assertFalse,
+    assertTrue
+}
+import ceylon.wrapper_type {
+    WrappedString
+}
+
+test
+void testWrappedString() {
+    class MyString1(String baseValue) extends WrappedString(baseValue) {}
+    class MyString2(String baseValue) extends WrappedString(baseValue) {}
+
+    value bob1 = MyString1("bob");
+
+    assertEquals(bob1.baseValue, "bob");
+    assertEquals(bob1.name, "MyString1");
+
+    value bob2 = MyString1("bob");
+
+    assertEquals(bob2, bob1);
+    assertEquals(bob2.hash, bob1.hash);
+    assertEquals(bob1.compare(bob2), equal);
+
+    value car = MyString1("car");
+
+    assertNotEquals(car, bob1);
+    assertNotEquals(car.hash, bob1.hash);
+    assertEquals(bob1.compare(car), smaller);
+
+    assertTrue(bob1 == bob2);
+    assertFalse(car == bob2);
+    assertFalse(bob1 == car);
+
+    value bob3 = MyString2("bob");
+
+    assertEquals(bob1, bob2);
+    assertNotEquals(bob1, bob3);
+    assertNotEquals(bob2, bob3);
+}

--- a/test-source/test/ceylon/wrapper_type/TestWrappedTypeComparable.ceylon
+++ b/test-source/test/ceylon/wrapper_type/TestWrappedTypeComparable.ceylon
@@ -1,0 +1,32 @@
+import ceylon.test {
+    test,
+    assertEquals,
+    assertNotEquals
+}
+import ceylon.wrapper_type {
+    WrappedTypedComparable
+}
+
+shared class Gorkle(String name) satisfies Comparable<Gorkle> {
+    shared actual Comparison compare(Gorkle other) => name.compare(other.name);
+}
+
+shared abstract class TypedGorkle(Gorkle baseValue)
+        extends WrappedTypedComparable<Gorkle>(baseValue) {}
+
+test
+void testTypedClassComprable() {
+    class MyGorkle1(Gorkle baseValue) extends TypedGorkle(baseValue) {}
+    class MyGorkle2(Gorkle baseValue) extends TypedGorkle(baseValue) {}
+
+    value gorkle = Gorkle("myGorkle");
+    value myGorkle1 = MyGorkle1(gorkle);
+    value myGorkle2 = MyGorkle2(gorkle);
+
+    assertEquals(myGorkle1.baseValue, gorkle);
+    assertEquals(myGorkle1.name, "MyGorkle1");
+    assertEquals(myGorkle1.baseValue, myGorkle2.baseValue);
+    assertNotEquals(myGorkle1, myGorkle2);
+    assertEquals(myGorkle1.compare(myGorkle1), equal);
+    //myGorkle1.compare(myGorkle2)); Compile error
+}

--- a/test-source/test/ceylon/wrapper_type/TestWrapperType.ceylon
+++ b/test-source/test/ceylon/wrapper_type/TestWrapperType.ceylon
@@ -1,0 +1,28 @@
+import ceylon.test {
+    test,
+    assertEquals,
+    assertNotEquals
+}
+import ceylon.wrapper_type {
+    WrapperType
+}
+
+shared class Gorfle(String name) {}
+
+shared abstract class WrappedGorfle(Gorfle baseValue)
+        extends WrapperType<Gorfle>(baseValue) {}
+
+test
+void testTypedClass() {
+    class MyGorfle1(Gorfle baseValue) extends WrappedGorfle(baseValue) {}
+    class MyGorfle2(Gorfle baseValue) extends WrappedGorfle(baseValue) {}
+
+    value gorfle = Gorfle("myGorfle");
+    value myGorfle1 = MyGorfle1(gorfle);
+    value myGorfle2 = MyGorfle2(gorfle);
+
+    assertEquals(myGorfle1.baseValue, gorfle);
+    assertEquals(myGorfle1.name, "MyGorfle1");
+    assertEquals(myGorfle1.baseValue, myGorfle2.baseValue);
+    assertNotEquals(myGorfle1, myGorfle2);
+}

--- a/test-source/test/ceylon/wrapper_type/module.ceylon
+++ b/test-source/test/ceylon/wrapper_type/module.ceylon
@@ -1,0 +1,4 @@
+module test.ceylon.wrapper_type "1.2.3" {
+    import ceylon.wrapper_type "1.2.3";
+    import ceylon.test "1.2.3";
+}

--- a/test-source/test/ceylon/wrapper_type/package.ceylon
+++ b/test-source/test/ceylon/wrapper_type/package.ceylon
@@ -1,0 +1,1 @@
+package test.ceylon.wrapper_type;

--- a/test-source/test/ceylon/wrapper_type/testDisplayNameForType.ceylon
+++ b/test-source/test/ceylon/wrapper_type/testDisplayNameForType.ceylon
@@ -1,0 +1,24 @@
+import ceylon.language.meta.model {
+    Type,
+    nothingType
+}
+import ceylon.test {
+    test,
+    assertEquals
+}
+import ceylon.wrapper_type {
+    displayNameForType
+}
+
+test
+shared void testDisplayNameForType() {
+    void assertMe(Type<> type, String expectedDisplayName) {
+        assertEquals(displayNameForType(type), expectedDisplayName);
+    }
+
+    assertMe(`String`, "String");
+    assertMe(`String|Integer`, "String|Integer");
+    assertMe(`Identifiable&Obtainable`, "Identifiable&Obtainable");
+    assertMe(`Identifiable&Obtainable|String`, "Identifiable&Obtainable|String");
+    assertMe(nothingType, "nothingType");
+}


### PR DESCRIPTION
Add wrapper types for commonly used types to add unique typing.  This is useful in contexts where several Integer variables are used for different concepts such as AccountNumber, ReferenceNumber, etc.  This adds more safety than raw [[Integer]]s or [[String]]s, etc, and prevents accidental equality that would otherwise occur with these types, or passing such values in the wrong other to functions, not to mention clearer and more self-documenting code for those who read it.

The idea comes from the following article:   

http://techblog.realestate.com.au/the-abject-failure-of-weak-typing/

The implementations of WrapperType include WrappedByte, WrappedBoolean, WrappedFloat, and WrappedInteger.  In addition, a WrappedTypedComparable exists as well as its subclass, WrappedString.  These are all meant to be subclassed by users (ex FirstName as a subclass of WrappedString). It is possible for implementors to created their own wrapper types.  For example, a Widget class may be wrapped with a WrappedWidget, which subclasses WrapperType.

Please look at the included unit tests for examples of usage and further clarity.

Feedback, suggestions, improvements, clearer documentation, style changes, etc are most welcome.