### PR TITLE
Emit TAP count at end of test run

### DIFF
--- a/source/ceylon/test/reporter/TapReporter.ceylon
+++ b/source/ceylon/test/reporter/TapReporter.ceylon
@@ -117,7 +117,10 @@ shared class TapReporter(write = print) satisfies TestListener {
     
     shared actual void testRunStarted(TestRunStartedEvent event) {
         write("TAP version 13");
-        write("1..``event.description.children.size``");
+    }
+    
+    shared actual void testRunFinished(TestRunFinishedEvent event) {
+        write("1..`` count - 1 ``");
     }
     
     shared actual void testFinished(TestFinishedEvent event) => writeProtocol(event);


### PR DESCRIPTION
Due to parameterized tests, we don't know in advance how many tests we will run. Fixes #561.

(I'm fairly sure it wasn't correct prior to the introduction of parameterized tests either, due to nested tests, but whatever, it's fixed now.)