### PR TITLE
Add support for writing the TAP report to a file

### DIFF
--- a/source/ceylon/test/engine/internal/Options.ceylon
+++ b/source/ceylon/test/engine/internal/Options.ceylon
@@ -7,9 +7,9 @@ class Options {
     shared String[] modules;
     shared String[] tests;
     shared String[] tags;
-    shared Boolean tap;
     shared Boolean report;
     shared Integer? port;
+    shared String? tap;
     shared String? colorReset;
     shared String? colorGreen;
     shared String? colorRed;
@@ -20,9 +20,9 @@ class Options {
         value testArgs = ArrayList<String>();
         value tagArgs = ArrayList<String>();
         variable value prev = "";
-        variable value tapArg = false;
         variable value reportArg = false;
         variable Integer? portArg = null;
+        variable String? tapArg = null;
         variable String? colorResetArg = process.propertyValue("``colorKeyPrefix``.reset");
         variable String? colorGreenArg = process.propertyValue("``colorKeyPrefix``.green");
         variable String? colorRedArg = process.propertyValue("``colorKeyPrefix``.red");
@@ -51,7 +51,10 @@ class Options {
                 portArg = p;
             }
             if (arg == "--tap") {
-                tapArg = true;
+                tapArg = "-";
+            }
+            if (arg.startsWith("--tap=")) {
+                tapArg = arg["--tap=".size...];
             }
             if (arg == "--report") {
                 reportArg = true;

--- a/source/ceylon/test/engine/internal/Runner.ceylon
+++ b/source/ceylon/test/engine/internal/Runner.ceylon
@@ -55,8 +55,25 @@ shared class Runner() {
         
         if (exists socket) {
             testListeners.add(TestEventPublisher(socket.write));
-        } else if (options.tap) {
-            testListeners.add(TapReporter());
+        } else if (exists tap = options.tap) {
+            void write(String? line);
+            if (tap == "-") {
+                write = void(String? line) {
+                    if (exists line) {
+                        print(line);
+                    }
+                };
+            } else {
+                value writer = FileWriter(tap);
+                write = void(String? line) {
+                    if (exists line) {
+                        writer.writeLine(line);
+                    } else {
+                        writer.destroy(null);
+                    }
+                };
+            }
+            testListeners.add(TapReporter(write));
         } else {
             testListeners.add(TestLoggingListener(options.colorReset, options.colorGreen, options.colorRed));
         }

--- a/source/ceylon/test/engine/internal/Runner.ceylon
+++ b/source/ceylon/test/engine/internal/Runner.ceylon
@@ -56,24 +56,15 @@ shared class Runner() {
         if (exists socket) {
             testListeners.add(TestEventPublisher(socket.write));
         } else if (exists tap = options.tap) {
-            void write(String? line);
             if (tap == "-") {
-                write = void(String? line) {
-                    if (exists line) {
-                        print(line);
-                    }
-                };
+                testListeners.add(TapReporter());
             } else {
                 value writer = FileWriter(tap);
-                write = void(String? line) {
-                    if (exists line) {
-                        writer.writeLine(line);
-                    } else {
-                        writer.destroy(null);
-                    }
-                };
+                testListeners.add(TapReporter {
+                        void write(String line) => writer.writeLine(line);
+                        void close() => writer.destroy(null);
+                    });
             }
-            testListeners.add(TapReporter(write));
         } else {
             testListeners.add(TestLoggingListener(options.colorReset, options.colorGreen, options.colorRed));
         }

--- a/source/ceylon/test/engine/internal/file.ceylon
+++ b/source/ceylon/test/engine/internal/file.ceylon
@@ -28,10 +28,11 @@ native ("jvm") shared class FileWriter(String path) satisfies Destroyable {
 }
 
 native ("js") shared class FileWriter(String path) satisfies Destroyable {
-    dynamic stream;
+    dynamic fsApi;
+    dynamic fd;
     dynamic {
         dynamic pathApi = require("path");
-        dynamic fsApi = require("fs");
+        fsApi = require("fs");
         
         value pathBuilder = StringBuilder();
         value pathSegments = path.split((Character c) => c.string == pathApi.sep).sequence();
@@ -45,22 +46,22 @@ native ("js") shared class FileWriter(String path) satisfies Destroyable {
         assert(exists pathLastSegment = pathSegments.last);
         pathBuilder.append(pathLastSegment);
         
-        stream = fsApi.createWriteStream(pathBuilder.string);
+        fd = fsApi.openSync(pathBuilder.string, "w");
     }
     
     native ("js") shared void write(String text) {
         dynamic {
-            stream.write(text);
+            fs.writeSync(fd, text);
         }
     }
     native ("js") shared void writeLine(String line) {
         dynamic {
-            stream.write(line + operatingSystem.newline);
+            fs.writeSync(fd, line + operatingSystem.newline);
         }
     }
     native ("js") shared actual void destroy(Throwable? error) {
         dynamic {
-            stream.end();
+            fs.close(fd);
         }
     }
 }    

--- a/source/ceylon/test/engine/internal/file.ceylon
+++ b/source/ceylon/test/engine/internal/file.ceylon
@@ -1,0 +1,66 @@
+import ceylon.file {
+    current,
+    Nil,
+    File,
+    ExistingResource
+}
+
+native shared class FileWriter(String path) satisfies Destroyable {
+    native shared void write(String text);
+    native shared void writeLine(String line);
+    native shared actual void destroy(Throwable? error);
+}
+
+native ("jvm") shared class FileWriter(String path) satisfies Destroyable {
+    File.Overwriter fw;
+    value res = current.childPath(path).resource;
+    switch(res)
+    case(is Nil) {
+        fw = res.createFile(true).Overwriter();
+    }
+    case(is ExistingResource) {
+        fw = res.delete().createFile(true).Overwriter();
+    }
+    
+    native ("jvm") shared void write(String text) => fw.write(text);
+    native ("jvm") shared void writeLine(String line) => fw.writeLine(line);
+    native ("jvm") shared actual void destroy(Throwable? error) => fw.close();
+}
+
+native ("js") shared class FileWriter(String path) satisfies Destroyable {
+    dynamic stream;
+    dynamic {
+        dynamic pathApi = require("path");
+        dynamic fsApi = require("fs");
+        
+        value pathBuilder = StringBuilder();
+        value pathSegments = path.split((Character c) => c.string == pathApi.sep).sequence();
+        for(pathSegment in pathSegments[0..pathSegments.size-2] ) {
+            pathBuilder.append(pathSegment);
+            if( !fsApi.existsSync(pathBuilder.string) ) {
+                fsApi.mkdirSync(pathBuilder.string);
+            }
+            pathBuilder.append(pathApi.sep);
+        }
+        assert(exists pathLastSegment = pathSegments.last);
+        pathBuilder.append(pathLastSegment);
+        
+        stream = fsApi.createWriteStream(pathBuilder.string);
+    }
+    
+    native ("js") shared void write(String text) {
+        dynamic {
+            stream.write(text);
+        }
+    }
+    native ("js") shared void writeLine(String line) {
+        dynamic {
+            stream.write(line + operatingSystem.newline);
+        }
+    }
+    native ("js") shared actual void destroy(Throwable? error) {
+        dynamic {
+            stream.end();
+        }
+    }
+}    

--- a/source/ceylon/test/reporter/TapReporter.ceylon
+++ b/source/ceylon/test/reporter/TapReporter.ceylon
@@ -108,12 +108,12 @@ import ceylon.test.engine {
          at com.redhat.ceylon.launcher.Launcher.main(Launcher.java:21)
    ...
  ~~~"
-shared class TapReporter(write) satisfies TestListener {
+shared class TapReporter(write = print, close = noop) satisfies TestListener {
     
-    "A function that logs the given line, for example by writing to standard output.
-     The function is called with a [[null]] argument at the end to signal the end of reporting;
-     this may be used to close an underlying stream if necessary."
-    void write(String? line);
+    "A function that logs the given line, for example [[print]]."
+    void write(String line);
+    "A function that is called at the end of reporting and may, for example, close an underlying stream."
+    void close();
     
     variable Integer count = 1;
     
@@ -123,7 +123,7 @@ shared class TapReporter(write) satisfies TestListener {
     
     shared actual void testRunFinished(TestRunFinishedEvent event) {
         write("1..`` count - 1 ``");
-        write(null); // close stream
+        close();
     }
     
     shared actual void testFinished(TestFinishedEvent event) => writeProtocol(event);

--- a/source/ceylon/test/reporter/TapReporter.ceylon
+++ b/source/ceylon/test/reporter/TapReporter.ceylon
@@ -108,10 +108,12 @@ import ceylon.test.engine {
          at com.redhat.ceylon.launcher.Launcher.main(Launcher.java:21)
    ...
  ~~~"
-shared class TapReporter(write = print) satisfies TestListener {
+shared class TapReporter(write) satisfies TestListener {
     
-    "A function that logs the given line, for example [[print]]."
-    void write(String line);
+    "A function that logs the given line, for example by writing to standard output.
+     The function is called with a [[null]] argument at the end to signal the end of reporting;
+     this may be used to close an underlying stream if necessary."
+    void write(String? line);
     
     variable Integer count = 1;
     
@@ -121,6 +123,7 @@ shared class TapReporter(write = print) satisfies TestListener {
     
     shared actual void testRunFinished(TestRunFinishedEvent event) {
         write("1..`` count - 1 ``");
+        write(null); // close stream
     }
     
     shared actual void testFinished(TestFinishedEvent event) => writeProtocol(event);


### PR DESCRIPTION
The `--tap` flag is changed to be an option, `--tap=filename`. Printing to standard output is still supported by using the file name `-` (dash).

(The file facade should eventually be replaced by using ceylon.file, once #239 is implemented.)

---

@bjansen this should make it easier to use the Jenkins TAP plugin with ceylon.formatter…