### PR TITLE
Improvements to test.ceylon.time

### DIFF
--- a/test-source/test/ceylon/time/testChronology.ceylon
+++ b/test-source/test/ceylon/time/testChronology.ceylon
@@ -1,6 +1,7 @@
 import ceylon.test {
     assertEquals,
-    test
+    test,
+    parameters
 }
 import ceylon.time {
     date,
@@ -16,39 +17,42 @@ import ceylon.time.chronology {
 }
 
 shared test void testUnixTime() {
-    assertEquals(719163, unixTime.epoch);
-    assertEquals(719163, unixTime.fixedFromTime(1));
-    assertEquals(1356998400000, unixTime.timeFromFixed(date(2013, january, 1).dayOfEra));
-    assertEquals(unixTime.timeOfDay(1357032630000), time(9, 30, 30).millisecondsOfDay);
+    assertEquals { expected = 719163; actual = unixTime.epoch; };
+    assertEquals { expected = 719163; actual = unixTime.fixedFromTime(1); };
+    assertEquals { expected = 1356998400000; actual = unixTime.timeFromFixed(date(2013, january, 1).dayOfEra); };
+    assertEquals { expected = unixTime.timeOfDay(1357032630000); actual = time(9, 30, 30).millisecondsOfDay; };
 }
 
-shared test void testGregorianMonths() {
-    assertEquals(1,  gregorian.january);
-    assertEquals(2,  gregorian.february);
-    assertEquals(3,  gregorian.march);
-    assertEquals(4,  gregorian.april);
-    assertEquals(5,  gregorian.may);
-    assertEquals(6,  gregorian.june);
-    assertEquals(7,  gregorian.july);
-    assertEquals(8,  gregorian.august);
-    assertEquals(9,  gregorian.september);
-    assertEquals(10, gregorian.october);
-    assertEquals(11, gregorian.november);
-    assertEquals(12, gregorian.december);
-}
+[[Integer, Integer]*] gregorianMonths = [
+    [1,  gregorian.january],
+    [2,  gregorian.february],
+    [3,  gregorian.march],
+    [4,  gregorian.april],
+    [5,  gregorian.may],
+    [6,  gregorian.june],
+    [7,  gregorian.july],
+    [8,  gregorian.august],
+    [9,  gregorian.september],
+    [10, gregorian.october],
+    [11, gregorian.november],
+    [12, gregorian.december]
+];
+parameters (`value gregorianMonths`)
+shared test void testGregorianMonths(Integer expectedMonth, Integer actualMonth)
+        => assertEquals { expected = expectedMonth; actual = actualMonth; };
 
 shared test void testGregorian() {
     gregorian.checkDate([2013, 1, 1]);
     gregorian.checkDate([2012, 2, 29]);
     gregorian.checkDate([2010, 12, 31]);
 
-    assertEquals([1970, 1, 1], gregorian.dateFrom(unixTime.epoch));
-    assertEquals(1, gregorian.dayFrom(unixTime.epoch));
-    assertEquals(tuesday.integer, gregorian.dayOfWeekFrom(735065));
-    assertEquals(719163, gregorian.fixedFrom([1970,1,1]));
+    assertEquals { expected = [1970, 1, 1]; actual = gregorian.dateFrom(unixTime.epoch); };
+    assertEquals { expected = 1; actual = gregorian.dayFrom(unixTime.epoch); };
+    assertEquals { expected = tuesday.integer; actual = gregorian.dayOfWeekFrom(735065); };
+    assertEquals { expected = 719163; actual = gregorian.fixedFrom([1970,1,1]); };
 
-    assertEquals(true, gregorian.leapYear(2012));
-    assertEquals(false, gregorian.leapYear(2010));
+    assertEquals { expected = true; actual = gregorian.leapYear(2012); };
+    assertEquals { expected = false; actual = gregorian.leapYear(2010); };
 
-    assertEquals(gregorian.january, gregorian.monthFrom(719163));
+    assertEquals { expected = gregorian.january; actual = gregorian.monthFrom(719163); };
 }

--- a/test-source/test/ceylon/time/testClock.ceylon
+++ b/test-source/test/ceylon/time/testClock.ceylon
@@ -3,14 +3,14 @@ import ceylon.time { systemTime, Instant, fixedTime, offsetTime, Duration }
 import ceylon.time.base { milliseconds }
 
 test shared void testSystemTimeString() {
-    assertEquals("System time", systemTime.string);
+    assertEquals { expected = "System time"; actual = systemTime.string; };
 }
 
 test shared void testFixedTimeString() {
-    assertEquals("Fixed to 2013-11-07T20:52:10.000Z", fixedTime(Instant(1383857530000)).string);
-    assertEquals("Fixed to 2013-11-07T20:52:10.000Z", fixedTime(1383857530000).string);
+    assertEquals { expected = "Fixed to 2013-11-07T20:52:10.000Z"; actual = fixedTime(Instant(1383857530000)).string; };
+    assertEquals { expected = "Fixed to 2013-11-07T20:52:10.000Z"; actual = fixedTime(1383857530000).string; };
 }
 
 test shared void testOffsetTimeString() {
-    assertEquals("Offset of PT1H from ``systemTime.string``", offsetTime(systemTime, Duration(milliseconds.perHour)).string);
+    assertEquals { expected = "Offset of PT1H from ``systemTime.string``"; actual = offsetTime(systemTime, Duration(milliseconds.perHour)).string; };
 }

--- a/test-source/test/ceylon/time/testDateRange.ceylon
+++ b/test-source/test/ceylon/time/testDateRange.ceylon
@@ -46,15 +46,15 @@ shared test void testEqualsAndHashDateRange() {
 }
 
 shared test void testStepDays() {
-    assertEquals(days, jan_date_range.step);
+    assertEquals { expected = days; actual = jan_date_range.step; };
 }
 
 shared test void testStepMonths() {
-    assertEquals(months, jan_date_range.stepBy(months).step);
+    assertEquals { expected = months; actual = jan_date_range.stepBy(months).step; };
 }
 
 shared test void testStepYears() {
-    assertEquals(years, jan_date_range.stepBy(years).step);
+    assertEquals { expected = years; actual = jan_date_range.stepBy(years).step; };
 }
 
 shared test void testAnyExist() {
@@ -95,14 +95,14 @@ shared test void testGapDate() {
     DateRange mar = date(2013, march, 1).rangeTo(date(2013, march, 31));
     DateRange gap = date(2013, february, 1).rangeTo(date(2013, february, 28));
     
-    assertEquals(gap, jan_date_range.gap(mar));
+    assertEquals { expected = gap; actual = jan_date_range.gap(mar); };
 }
 
 shared test void testGapDateReverse() {
     DateRange mar = date(2013, march, 1).rangeTo(date(2013, march,31));
     DateRange gap = date(2013, february, 1).rangeTo(date(2013, february, 28));
     
-    assertEquals(gap, jan_date_range_reverse.gap(mar));
+    assertEquals { expected = gap; actual = jan_date_range_reverse.gap(mar); };
 }
 
 shared test void testGapDateOneYear() {
@@ -110,54 +110,54 @@ shared test void testGapDateOneYear() {
     DateRange _2015 = date(2015, january, 1).rangeTo(date(2015, december, 31));
 
     DateRange _2014 = date(2014, january, 1).rangeTo(date(2014, december, 31));
-    assertEquals(_2014, _2015.gap(_2013));
+    assertEquals { expected = _2014; actual = _2015.gap(_2013); };
 }
 
 shared test void testGapDateEmpty() {
     DateRange feb = date(2013, february, 1).rangeTo(date(2013, february,28));
     
-    assertEquals(empty, jan_date_range_reverse.gap(feb));
+    assertEquals { expected = empty; actual = jan_date_range_reverse.gap(feb); };
 }
 
 shared test void testOverlapDateEmpty() {
     DateRange decemberRange = date(2013, december, 1).rangeTo(date(2013, december, 31));
 
-    assertEquals(empty, jan_date_range.overlap(decemberRange));
+    assertEquals { expected = empty; actual = jan_date_range.overlap(decemberRange); };
 }
 
 shared test void testOverlapDate() {
     DateRange halfJan = date(2013, january, 5).rangeTo(date(2013, january, 15));
     DateRange overlap = date(2013, january, 5).rangeTo(date(2013, january, 15));
 
-    assertEquals(overlap, jan_date_range.overlap(halfJan));
+    assertEquals { expected = overlap; actual = jan_date_range.overlap(halfJan); };
 }
 
 shared test void testStepDayReverse() {
-    assertEquals( 31, jan_date_range_reverse.size);
-    assertEquals( date(2013, january, 31), jan_date_range_reverse.first);
-    assertEquals( date(2013, january, 1), jan_date_range_reverse.last);
+    assertEquals { expected = 31; actual = jan_date_range_reverse.size; };
+    assertEquals { expected = date(2013, january, 31); actual = jan_date_range_reverse.first; };
+    assertEquals { expected = date(2013, january, 1); actual = jan_date_range_reverse.last; };
 }
 
 shared test void testStepMonthReverse() {
     DateRange interval = jan_date_range_reverse.stepBy(months);
-    assertEquals( 1, interval.size);
-    assertEquals( date(2013, january, 31), interval.first);
-    assertEquals( date(2013, january, 31), interval.last);
+    assertEquals { expected = 1; actual = interval.size; };
+    assertEquals { expected = date(2013, january, 31); actual = interval.first; };
+    assertEquals { expected = date(2013, january, 31); actual = interval.last; };
 }
 
 shared test void testStepYearReverse() {
     DateRange interval = jan_date_range_reverse.stepBy(years);
-    assertEquals( 1, interval.size);
-    assertEquals( date(2013, january, 31), interval.first);
-    assertEquals( date(2013, january, 31), interval.last);
+    assertEquals { expected = 1; actual = interval.size; };
+    assertEquals { expected = date(2013, january, 31); actual = interval.first; };
+    assertEquals { expected = date(2013, january, 31); actual = interval.last; };
 }
 
 shared test void testContainsDate() {
-    assertEquals(true, date(2013, january, 15) in jan_date_range);    
+    assertTrue(date(2013, january, 15) in jan_date_range);    
 }
 
 shared test void testNotContainsDate() {
-    assertEquals(false, date(2013, january, 15) in jan_date_range.stepBy(years));   
+    assertFalse(date(2013, january, 15) in jan_date_range.stepBy(years));   
 }
 
 shared test void testGapRulesABSmallerCD() {
@@ -317,21 +317,21 @@ shared test void testOverlapRulesABHigherCD() {
 }
 
 test void testDateRangeString() {
-    assertEquals( "2013-10-01/2013-10-31", DateRange(date(2013, october, 1), date(2013, october, 31)).string );
-    assertEquals( "2014-01-01/2013-01-01", DateRange(date(2014, january, 1), date(2013, january, 1)).string );
+    assertEquals { expected = "2013-10-01/2013-10-31"; actual = DateRange(date(2013, october, 1), date(2013, october, 31)).string; };
+    assertEquals { expected = "2014-01-01/2013-01-01"; actual = DateRange(date(2014, january, 1), date(2013, january, 1)).string; };
 }
 
 void assertIntervalDate( Date start, Date end, Period period, Duration? duration = null )  {
     value range = start.rangeTo(end);
-    assertEquals(period, range.period);
+    assertEquals { expected = period; actual = range.period; };
 
-    assertEquals( end, start.plus(period) );
-    assertEquals( start, end.minus(period) );
+    assertEquals { expected = end; actual = start.plus(period); };
+    assertEquals { expected = start; actual = end.minus(period); };
 
-    assertEquals( start, range.first );
-    assertEquals( end, range.last );
+    assertEquals { expected = start; actual = range.first; };
+    assertEquals { expected = end; actual = range.last; };
 
     if( exists duration ) {
-        assertEquals(duration, range.duration);
+        assertEquals { expected = duration; actual = range.duration; };
     }
 }

--- a/test-source/test/ceylon/time/testDateTime.ceylon
+++ b/test-source/test/ceylon/time/testDateTime.ceylon
@@ -29,7 +29,7 @@ import ceylon.time.base {
     april
 }
 
-DateTime data_1982_12_13_09_08_07_0050 = dateTime {
+DateTime date_1982_12_13_09_08_07_0050 = dateTime {
     year = 1982; month = december; day = 13;
     hours = 9; minutes = 8; seconds = 7; milliseconds = 50;
 };
@@ -68,96 +68,96 @@ shared test void testEqualsAndHashDateTime() {
 }
 
 shared test void testPlusYears() {
-    assertEquals( 2000, data_1982_12_13_09_08_07_0050.plusYears(18).year);
+    assertEquals { expected = 2000; actual = date_1982_12_13_09_08_07_0050.plusYears(18).year; };
 }
 
 shared test void testMinusYears() {
-    assertEquals( 1964, data_1982_12_13_09_08_07_0050.minusYears(18).year);
+    assertEquals { expected = 1964; actual = date_1982_12_13_09_08_07_0050.minusYears(18).year; };
 }
 
 shared test void testPlusMonths() {
-    assertEquals( january, data_1982_12_13_09_08_07_0050.plusMonths(1).month);
+    assertEquals { expected = january; actual = date_1982_12_13_09_08_07_0050.plusMonths(1).month; };
 }
 
 shared test void testMinusMonths() {
-    assertEquals( november, data_1982_12_13_09_08_07_0050.minusMonths(1).month);
+    assertEquals { expected = november; actual = date_1982_12_13_09_08_07_0050.minusMonths(1).month; };
 }
 
 shared test void testPlusDays() {
-    assertEquals( 15, data_1982_12_13_09_08_07_0050.plusDays(2).day);
+    assertEquals { expected = 15; actual = date_1982_12_13_09_08_07_0050.plusDays(2).day; };
 }
 
 shared test void testMinusDays() {
-    assertEquals( 9, data_1982_12_13_09_08_07_0050.minusDays(4).day);
+    assertEquals { expected = 9; actual = date_1982_12_13_09_08_07_0050.minusDays(4).day; };
 }
 
 shared test void testPlusHours_DateTime() {
-    assertEquals( 18, data_1982_12_13_09_08_07_0050.plusHours(9).hours);
+    assertEquals { expected = 18; actual = date_1982_12_13_09_08_07_0050.plusHours(9).hours; };
 
-    value data_1982_12_14_13 = data_1982_12_13_09_08_07_0050.plusHours(28); 
-    assertEquals( 13, data_1982_12_14_13.hours);
-    assertEquals( 14, data_1982_12_14_13.day);
+    value date_1982_12_14_13 = date_1982_12_13_09_08_07_0050.plusHours(28); 
+    assertEquals { expected = 13; actual = date_1982_12_14_13.hours; };
+    assertEquals { expected = 14; actual = date_1982_12_14_13.day; };
 }
 
 shared test void testMinusHours_DateTime() {
-    assertEquals( 2, data_1982_12_13_09_08_07_0050.minusHours(7).hours);
+    assertEquals { expected = 2; actual = date_1982_12_13_09_08_07_0050.minusHours(7).hours; };
 
-    value data_1982_12_12_5 = data_1982_12_13_09_08_07_0050.minusHours(28);
-    assertEquals( 5, data_1982_12_12_5.hours);
-    assertEquals( 12, data_1982_12_12_5.day);
+    value date_1982_12_12_5 = date_1982_12_13_09_08_07_0050.minusHours(28);
+    assertEquals { expected = 5; actual = date_1982_12_12_5.hours; };
+    assertEquals { expected = 12; actual = date_1982_12_12_5.day; };
 }
 
 shared test void testPlusMinutes_DateTime() {
-    assertEquals( 15, data_1982_12_13_09_08_07_0050.plusMinutes(7).minutes);
+    assertEquals { expected = 15; actual = date_1982_12_13_09_08_07_0050.plusMinutes(7).minutes; };
 
-    value data_1982_12_13_10_3 = data_1982_12_13_09_08_07_0050.plusMinutes(55);
-    assertEquals( 3, data_1982_12_13_10_3.minutes);
-    assertEquals( 10, data_1982_12_13_10_3.hours);
+    value date_1982_12_13_10_3 = date_1982_12_13_09_08_07_0050.plusMinutes(55);
+    assertEquals { expected = 3; actual = date_1982_12_13_10_3.minutes; };
+    assertEquals { expected = 10; actual = date_1982_12_13_10_3.hours; };
 }
 
 shared test void testMinusMinutes_DateTime() {
-    assertEquals( 15, data_1982_12_13_09_08_07_0050.plusMinutes(7).minutes);
+    assertEquals { expected = 15; actual = date_1982_12_13_09_08_07_0050.plusMinutes(7).minutes; };
 
-    value data_1982_12_13_8_15 = data_1982_12_13_09_08_07_0050.minusMinutes(53);
-    assertEquals( 15, data_1982_12_13_8_15.minutes);
-    assertEquals( 8, data_1982_12_13_8_15.hours);    
+    value date_1982_12_13_8_15 = date_1982_12_13_09_08_07_0050.minusMinutes(53);
+    assertEquals { expected = 15; actual = date_1982_12_13_8_15.minutes; };
+    assertEquals { expected = 8; actual = date_1982_12_13_8_15.hours; };    
 }
 
 shared test void testPlusSeconds_DateTime() {
-    assertEquals( 16, data_1982_12_13_09_08_07_0050.plusSeconds(9).seconds);
+    assertEquals { expected = 16; actual = date_1982_12_13_09_08_07_0050.plusSeconds(9).seconds; };
 
-    value data_1982_12_13_9_9_15 = data_1982_12_13_09_08_07_0050.plusSeconds(53+15);
-    assertEquals( 15, data_1982_12_13_9_9_15.seconds);
-    assertEquals( 9, data_1982_12_13_9_9_15.minutes);
+    value date_1982_12_13_9_9_15 = date_1982_12_13_09_08_07_0050.plusSeconds(53+15);
+    assertEquals { expected = 15; actual = date_1982_12_13_9_9_15.seconds; };
+    assertEquals { expected = 9; actual = date_1982_12_13_9_9_15.minutes; };
 }
 
 shared test void testMinusSeconds_DateTime() {
-    assertEquals( 15, data_1982_12_13_09_08_07_0050.plusMinutes(7).minutes);
+    assertEquals { expected = 15; actual = date_1982_12_13_09_08_07_0050.plusMinutes(7).minutes; };
 
-    value data_1982_12_13_9_7_4 = data_1982_12_13_09_08_07_0050.minusSeconds(7+56);
-    assertEquals( 4, data_1982_12_13_9_7_4.seconds);
-    assertEquals( 7, data_1982_12_13_9_7_4.minutes);
+    value date_1982_12_13_9_7_4 = date_1982_12_13_09_08_07_0050.minusSeconds(7+56);
+    assertEquals { expected = 4; actual = date_1982_12_13_9_7_4.seconds; };
+    assertEquals { expected = 7; actual = date_1982_12_13_9_7_4.minutes; };
 }
 
 shared test void testPlusMillis_DateTime() {
-    assertEquals( 150, data_1982_12_13_09_08_07_0050.plusMilliseconds(100).milliseconds);
+    assertEquals { expected = 150; actual = date_1982_12_13_09_08_07_0050.plusMilliseconds(100).milliseconds; };
 
-    value data_1982_12_13_9_8_15_300 = data_1982_12_13_09_08_07_0050.plusMilliseconds(950+7300);
-    assertEquals( 300, data_1982_12_13_9_8_15_300.milliseconds);
-    assertEquals( 15, data_1982_12_13_9_8_15_300.seconds);
+    value date_1982_12_13_9_8_15_300 = date_1982_12_13_09_08_07_0050.plusMilliseconds(950+7300);
+    assertEquals { expected = 300; actual = date_1982_12_13_9_8_15_300.milliseconds; };
+    assertEquals { expected = 15; actual = date_1982_12_13_9_8_15_300.seconds; };
 }
 
 shared test void testMinusMilliseconds_DateTime() {
-    assertEquals( 950, data_1982_12_13_09_08_07_0050.minusMilliseconds(100).milliseconds);
+    assertEquals { expected = 950; actual = date_1982_12_13_09_08_07_0050.minusMilliseconds(100).milliseconds; };
 
-    value data_1982_12_13_9_8_4_100 = data_1982_12_13_09_08_07_0050.minusMilliseconds(50+2900);
-    assertEquals( 100, data_1982_12_13_9_8_4_100.milliseconds);
-    assertEquals( 4, data_1982_12_13_9_8_4_100.seconds);
+    value date_1982_12_13_9_8_4_100 = date_1982_12_13_09_08_07_0050.minusMilliseconds(50+2900);
+    assertEquals { expected = 100; actual = date_1982_12_13_9_8_4_100.milliseconds; };
+    assertEquals { expected = 4; actual = date_1982_12_13_9_8_4_100.seconds; };
 }
 
 shared test void testWithDay40_DateTime() {
     try {
-        data_1982_12_13_09_08_07_0050.withDay(40);
+        date_1982_12_13_09_08_07_0050.withDay(40);
         fail("Should throw exception...");
     } catch( AssertionError e ) {
         assertTrue(e.message.contains("Invalid date"));
@@ -166,7 +166,7 @@ shared test void testWithDay40_DateTime() {
 
 shared test void testWithDay0_DateTime() {
     try {
-        data_1982_12_13_09_08_07_0050.withDay(0);
+        date_1982_12_13_09_08_07_0050.withDay(0);
         fail("Should throw exception...");
     } catch( AssertionError e ) {
         assertTrue(e.message.contains("Invalid date"));
@@ -175,7 +175,7 @@ shared test void testWithDay0_DateTime() {
 
 shared test void testWithDayNegative_DateTime() {
     try {
-        data_1982_12_13_09_08_07_0050.withDay(-10);
+        date_1982_12_13_09_08_07_0050.withDay(-10);
         fail("Should throw exception...");
     } catch( AssertionError e ) {
         assertTrue(e.message.contains("Invalid date"));
@@ -197,7 +197,7 @@ shared test void testWithDay29FebLeap_DateTime() {
 
 shared test void testPredecessor_DateTime() {
     assertEquals{ 
-        actual = data_1982_12_13_09_08_07_0050.predecessor; 
+        actual = date_1982_12_13_09_08_07_0050.predecessor; 
         expected = dateTime { 
             year = 1982; month = december; day = 13; 
             hours = 9; minutes = 8; seconds = 7; milliseconds = 49;
@@ -207,7 +207,7 @@ shared test void testPredecessor_DateTime() {
 
 shared test void testSuccessor_DateTime() {
     assertEquals{ 
-        actual = data_1982_12_13_09_08_07_0050.successor; 
+        actual = date_1982_12_13_09_08_07_0050.successor; 
         expected = dateTime {
             year = 1982; month = december; day = 13; 
             hours = 9; minutes = 8; seconds = 7; milliseconds = 51;
@@ -373,20 +373,20 @@ shared test void testPeriodNextStepByMs_DateTime() {
     value from = dateTime(2013, april, 19, 17, 59,59);
     value to = dateTime(2013, april, 19, 18, 0);
 
-    assertEquals( 1001, from.rangeTo(to).size );
+    assertEquals { expected = 1001; actual = from.rangeTo(to).size; };
 }
 
 shared test void testPeriodPreviousStepByMs_DateTime() {
     value from = dateTime(2013, april, 19, 18, 0);
     value to = dateTime(2013, april, 19, 17, 59,59);
 
-    assertEquals( 1001, from.rangeTo(to).size );
+    assertEquals { expected = 1001; actual = from.rangeTo(to).size; };
 }
 
 shared test void testEnumerableDateTime() {
-    assertEquals(data_1982_12_13_09_08_07_0050.offset(data_1982_12_13_09_08_07_0050), 0);
-    assertEquals(data_1982_12_13_09_08_07_0050.successor.offset(data_1982_12_13_09_08_07_0050), 1);
-    assertEquals(data_1982_12_13_09_08_07_0050.predecessor.offset(data_1982_12_13_09_08_07_0050), - 1);
+    assertEquals(date_1982_12_13_09_08_07_0050.offset(date_1982_12_13_09_08_07_0050), 0);
+    assertEquals(date_1982_12_13_09_08_07_0050.successor.offset(date_1982_12_13_09_08_07_0050), 1);
+    assertEquals(date_1982_12_13_09_08_07_0050.predecessor.offset(date_1982_12_13_09_08_07_0050), - 1);
 }
 
 shared test void testPeriodFromNewYear_DateTimeNegative() {
@@ -410,10 +410,10 @@ shared test void testPeriodTimeStep() {
 }
 
 shared test void testStringDateTime() {
-    assertEquals("1982-12-13T09:08:07.050", data_1982_12_13_09_08_07_0050.string);
-    assertEquals("0000-12-13T09:08:07.050", data_1982_12_13_09_08_07_0050.withYear(0).string);
-    assertEquals("0010-12-13T09:08:07.050", data_1982_12_13_09_08_07_0050.withYear(10).string);
-    assertEquals("0100-12-13T09:08:07.050", data_1982_12_13_09_08_07_0050.withYear(100).string);
+    assertEquals { expected = "1982-12-13T09:08:07.050"; actual = date_1982_12_13_09_08_07_0050.string; };
+    assertEquals { expected = "0000-12-13T09:08:07.050"; actual = date_1982_12_13_09_08_07_0050.withYear(0).string; };
+    assertEquals { expected = "0010-12-13T09:08:07.050"; actual = date_1982_12_13_09_08_07_0050.withYear(10).string; };
+    assertEquals { expected = "0100-12-13T09:08:07.050"; actual = date_1982_12_13_09_08_07_0050.withYear(100).string; };
 }
 
 void assertFromToDateTime( Period period, DateTime from, DateTime to ) {
@@ -426,20 +426,26 @@ void assertFromToDateTime( Period period, DateTime from, DateTime to ) {
       actual = from.periodTo( to );
     };
 
-    assertEquals(to, from.plus(period));
-    assertEquals(from, to.minus(period));
+    assertEquals {
+        expected = to;
+        actual = from.plus(period);
+    };
+    assertEquals {
+        expected = from;
+        actual = to.minus(period);
+    };
 }
 
 void assertGregorianDateTime( Integer year, Month month, Integer day, DayOfWeek dayOfWeek, Boolean leapYear = false, 
                               Integer hour = 0, Integer minute = 0, Integer second = 0, Integer milli = 0) {
     value actual = dateTime(year, month, day, hour, minute, second, milli);
-    assertEquals(year, actual.year);
-    assertEquals(month, actual.month);
-    assertEquals(day, actual.day);
-    assertEquals(dayOfWeek, actual.dayOfWeek);
-    assertEquals(leapYear, actual.leapYear);
-    assertEquals(hour, actual.hours);
-    assertEquals(minute, actual.minutes);
-    assertEquals(second, actual.seconds);
-    assertEquals(milli, actual.milliseconds);
+    assertEquals(actual.year, year);
+    assertEquals(actual.month, month);
+    assertEquals(actual.day, day);
+    assertEquals(actual.dayOfWeek, dayOfWeek);
+    assertEquals(actual.leapYear, leapYear);
+    assertEquals(actual.hours, hour);
+    assertEquals(actual.minutes, minute);
+    assertEquals(actual.seconds, second);
+    assertEquals(actual.milliseconds, milli);
 }

--- a/test-source/test/ceylon/time/testDateTimeRange.ceylon
+++ b/test-source/test/ceylon/time/testDateTimeRange.ceylon
@@ -48,7 +48,7 @@ shared test void testEqualsAndHashDateTimeRange() {
 }
 
 shared test void testStepDateTime() {
-    assertEquals(days, jan_date_range.step);
+    assertEquals { expected = days; actual = jan_date_range.step; };
 }
 
 shared test void testAnyExistDateTime() {
@@ -88,58 +88,58 @@ shared test void testIntervalDateTimeReverse() {
 shared test void testGapDateTimeEmpty() {
     DateTimeRange feb = dateTime(2013, january, 1).rangeTo(dateTime(2013, january,28));
     
-    assertEquals(empty, jan_date_time_range.gap(feb));    
+    assertEquals { expected = empty; actual = jan_date_time_range.gap(feb); };
 }
 
 shared test void testOverlapDateTimeEmpty() {
     DateTimeRange decemberRange = dateTime(2013, december, 1).rangeTo(dateTime(2013, december, 31));
 
-    assertEquals(empty, jan_date_time_range.overlap(decemberRange));
+    assertEquals { expected = empty; actual = jan_date_time_range.overlap(decemberRange); };
 }
 
 shared test void testGapDateTime() {
     DateRange mar = date(2013, march, 1).rangeTo(date(2013, march, 31));
     DateRange gap = date(2013, february, 1).rangeTo(date(2013, february, 28));
     
-    assertEquals(gap, jan_date_range.gap(mar));
+    assertEquals { expected = gap; actual = jan_date_range.gap(mar); };
 }
 
 shared test void testGapDateTimeReverse() {
     DateRange mar = date(2013, march, 1).rangeTo(date(2013, march,31));
     DateRange gap = date(2013, february, 1).rangeTo(date(2013, february, 28));
     
-    assertEquals(gap, jan_date_range_reverse.gap(mar));
+    assertEquals { expected = gap; actual = jan_date_range_reverse.gap(mar); };
 }
 
 shared test void testOverlapDateTime() {
     DateRange halfJan = date(2013, january, 5).rangeTo(date(2013, january, 15));
     DateRange overlap = date(2013, january, 5).rangeTo(date(2013, january, 15));
 
-    assertEquals(overlap, jan_date_range.overlap(halfJan));
+    assertEquals { expected = overlap; actual = jan_date_range.overlap(halfJan); };
 }
 
 shared test void testStepDayReverseDateTime() {
-    assertEquals( 31, jan_date_range_reverse.size);
-    assertEquals( date(2013, january, 31), jan_date_range_reverse.first);
-    assertEquals( date(2013, january, 1), jan_date_range_reverse.last);
+    assertEquals { expected = 31; actual = jan_date_range_reverse.size; };
+    assertEquals { expected = date { year = 2013; month = january; day = 31; }; actual = jan_date_range_reverse.first; };
+    assertEquals { expected = date(2013, january, 1); actual = jan_date_range_reverse.last; };
 }
 
 shared test void testStepMonthReverseDateTime() {
     DateRange interval = jan_date_range_reverse.stepBy(months);
-    assertEquals( 1, interval.size);
-    assertEquals( date(2013, january, 31), interval.first);
-    assertEquals( date(2013, january, 31), interval.last);
+    assertEquals { expected = 1; actual = interval.size; };
+    assertEquals { expected = date(2013, january, 31); actual = interval.first; };
+    assertEquals { expected = date(2013, january, 31); actual = interval.last; };
 }
 
 shared test void testStepYearReverseDateTime() {
     DateRange interval = jan_date_range_reverse.stepBy(years);
-    assertEquals( 1, interval.size);
-    assertEquals( date(2013, january, 31), interval.first);
-    assertEquals( date(2013, january, 31), interval.last);
+    assertEquals { expected = 1; actual = interval.size; };
+    assertEquals { expected = date(2013, january, 31); actual = interval.first; };
+    assertEquals { expected = date(2013, january, 31); actual = interval.last; };
 }
 
 shared test void testContainsDateTime() {
-    assertEquals(true, date(2013, january, 15) in jan_date_range);
+    assertEquals { expected = true; actual = date(2013, january, 15) in jan_date_range; };
 }
 
 shared test void testGapRulesABSmallerCD_DateTime() {
@@ -299,21 +299,21 @@ shared test void testOverlapRulesABHigherCD_DateTime() {
 }
 
 test void testDateTimeRangeString() {
-    assertEquals( "2013-10-01T09:10:11.000/2013-10-31T11:00:00.999", DateTimeRange(dateTime(2013, october, 1, 9, 10, 11), dateTime(2013, october, 31, 11, 0, 0, 999)).string );
-    assertEquals( "2014-01-01T23:00:00.000/2013-01-01T00:00:00.000", DateTimeRange(dateTime(2014, january, 1, 23), dateTime(2013, january, 1)).string );
+    assertEquals { expected = "2013-10-01T09:10:11.000/2013-10-31T11:00:00.999"; actual = DateTimeRange(dateTime(2013, october, 1, 9, 10, 11), dateTime(2013, october, 31, 11, 0, 0, 999)).string; };
+    assertEquals { expected = "2014-01-01T23:00:00.000/2013-01-01T00:00:00.000"; actual = DateTimeRange(dateTime(2014, january, 1, 23), dateTime(2013, january, 1)).string; };
 }
 
 void assertIntervalDateTime( Date start, Date end, Period period, Duration? duration = null )  {
     value range = start.rangeTo(end);
-    assertEquals(period, range.period);
+    assertEquals { expected = period; actual = range.period; };
 
-    assertEquals( end, start.plus(period) );
-    assertEquals( start, end.minus(period) );
+    assertEquals { expected = end; actual = start.plus(period); };
+    assertEquals { expected = start; actual = end.minus(period); };
 
-    assertEquals( start, range.first );
-    assertEquals( end, range.last );
+    assertEquals { expected = start; actual = range.first; };
+    assertEquals { expected = end; actual = range.last; };
 
     if( exists duration ) {
-        assertEquals(duration, range.duration);
+        assertEquals { expected = duration; actual = range.duration; };
     }
 }

--- a/test-source/test/ceylon/time/testDates.ceylon
+++ b/test-source/test/ceylon/time/testDates.ceylon
@@ -2,7 +2,6 @@ import ceylon.test {
     assertEquals,
     assertTrue,
     assertFalse,
-    fail,
     test,
     assertThat = assertThatException
 }
@@ -36,7 +35,7 @@ import ceylon.time.base {
 
 // Constants
 Boolean leapYear = true;
-Date data_1982_12_13 = date( 1982, december, 13);
+Date date_1982_12_13 = date( 1982, december, 13);
 
 // Table of test data from the book Calendrical Calculations
 shared test void test_sun_jul_24_minus586() => assertGregorianDate(-586, july, 24, sunday, !leapYear, 205);
@@ -101,30 +100,30 @@ shared test void testWeekOfYear() {
 }
 
 shared test void testDatePlusDays() {
-    assertEquals( data_1982_12_13.plusDays( 0 ), data_1982_12_13 );
-    assertEquals( data_1982_12_13.plusDays( 5 ), date( 1982, december, 18 ) );
-    assertEquals( data_1982_12_13.plusDays( 45 ), date( 1983, january, 27 ) );
-    assertEquals( data_1982_12_13.plusDays( 10954 ), date( 2012, december, 9 ) );
+    assertEquals( date_1982_12_13.plusDays( 0 ), date_1982_12_13 );
+    assertEquals( date_1982_12_13.plusDays( 5 ), date( 1982, december, 18 ) );
+    assertEquals( date_1982_12_13.plusDays( 45 ), date( 1983, january, 27 ) );
+    assertEquals( date_1982_12_13.plusDays( 10954 ), date( 2012, december, 9 ) );
 }
 
 shared test void testDateMinusDays() {
-    assertEquals( data_1982_12_13.minusDays( 5 ), date( 1982, december, 8 ) );
-    assertEquals( data_1982_12_13.minusDays( 0 ), data_1982_12_13 );
-    assertEquals( date( 2012, december, 9 ).minusDays( 10954 ), data_1982_12_13 );
+    assertEquals( date_1982_12_13.minusDays( 5 ), date( 1982, december, 8 ) );
+    assertEquals( date_1982_12_13.minusDays( 0 ), date_1982_12_13 );
+    assertEquals( date( 2012, december, 9 ).minusDays( 10954 ), date_1982_12_13 );
 }
 
 shared test void testDatePlusMonthsLessDays() {
-    assertEquals( date(1983, february, 28), date(1982,december,31).plusMonths(2));
+    assertEquals( date(1982,december,31).plusMonths(2), date(1983, february, 28) );
 }
 
 shared test void testDatePlusMonths() {
-    assertEquals( data_1982_12_13.plusMonths(0), data_1982_12_13 );
-    assertEquals( data_1982_12_13.plusMonths(1), date( 1983, january, 13) );
-    assertEquals( data_1982_12_13.plusMonths(12), date( 1983, december, 13) );
-    assertEquals( data_1982_12_13.plusMonths(36), date( 1985, december, 13) );
+    assertEquals( date_1982_12_13.plusMonths(0), date_1982_12_13 );
+    assertEquals( date_1982_12_13.plusMonths(1), date( 1983, january, 13) );
+    assertEquals( date_1982_12_13.plusMonths(12), date( 1983, december, 13) );
+    assertEquals( date_1982_12_13.plusMonths(36), date( 1985, december, 13) );
 
-    value data_2000_01_31 = date( 2000, january, 31 );
-    assertEquals( data_2000_01_31.plusMonths(14), date( 2001, march, 31) );
+    value date_2000_01_31 = date( 2000, january, 31 );
+    assertEquals( date_2000_01_31.plusMonths(14), date( 2001, march, 31) );
 }
 
 shared test void february29_plus_48_months() 
@@ -135,129 +134,102 @@ shared test void february29_plus_4_years()
 
 
 shared test void testDateMinusMonths() {
-    assertEquals( data_1982_12_13.minusMonths(0), data_1982_12_13 );
-    assertEquals( data_1982_12_13.minusMonths(1), date( 1982, november, 13) );
-    assertEquals( data_1982_12_13.minusMonths(12), date( 1981, december, 13) );
+    assertEquals( date_1982_12_13.minusMonths(0), date_1982_12_13 );
+    assertEquals( date_1982_12_13.minusMonths(1), date( 1982, november, 13) );
+    assertEquals( date_1982_12_13.minusMonths(12), date( 1981, december, 13) );
 }
 
 shared test void testDateMinusLessDays() {
-    assertEquals( date(1982,november,30), date(1982,december,31).minusMonths(1));
+    assertEquals( date(1982,december,31).minusMonths(1), date(1982,november,30) );
 }
 
 shared test void testDatePlusYears() {
-    assertEquals( data_1982_12_13.plusYears(0), data_1982_12_13 );
-    assertEquals( data_1982_12_13.plusYears(18), date( 2000, december, 13) );
-    assertEquals( data_1982_12_13.plusYears(30), date( 2012, december, 13) );
+    assertEquals( date_1982_12_13.plusYears(0), date_1982_12_13 );
+    assertEquals( date_1982_12_13.plusYears(18), date( 2000, december, 13) );
+    assertEquals( date_1982_12_13.plusYears(30), date( 2012, december, 13) );
 }
 
 shared test void testPlusYearsLessDays() {
-    assertEquals( date(2013, february, 28), date(2012, february, 29).plusYears(1));
+    assertEquals( date(2012, february, 29).plusYears(1), date(2013, february, 28) );
 }
 
 shared test void testDateMinusYears() {
-    value data_2000_01_31 = date( 2000, january, 31);
-    assertEquals( data_2000_01_31.minusYears(1), date( 1999, january, 31) );
-    assertEquals( data_1982_12_13.minusYears(10), date( 1972, december, 13) );
+    value date_2000_01_31 = date( 2000, january, 31);
+    assertEquals( date_2000_01_31.minusYears(1), date( 1999, january, 31) );
+    assertEquals( date_1982_12_13.minusYears(10), date( 1972, december, 13) );
 }
 
 shared test void testMinusYearsLessDays() {
-    assertEquals( date(2011, february, 28), date(2012, february, 29).minusYears(1));
+    assertEquals( date(2012, february, 29).minusYears(1), date(2011, february, 28) );
 }
 
 shared test void testDatePlusWeeks() {
-    assertEquals( data_1982_12_13.plusWeeks(1).dayOfWeek, data_1982_12_13.dayOfWeek );
-    assertEquals( data_1982_12_13.plusWeeks(1), date( 1982, december, 20) );
-    assertEquals( data_1982_12_13.plusWeeks(3), date( 1983, january, 3) );
+    assertEquals( date_1982_12_13.plusWeeks(1).dayOfWeek, date_1982_12_13.dayOfWeek );
+    assertEquals( date_1982_12_13.plusWeeks(1), date( 1982, december, 20) );
+    assertEquals( date_1982_12_13.plusWeeks(3), date( 1983, january, 3) );
 }
 
 shared test void testDateMinusWeeks(){
-    assertEquals( data_1982_12_13.minusWeeks(1), date( 1982, december, 6) );
-    assertEquals( data_1982_12_13.minusWeeks(3), date( 1982, november, 22) );
-    assertEquals( data_1982_12_13.minusWeeks(3).dayOfWeek, date( 1982, november, 22).dayOfWeek );
+    assertEquals( date_1982_12_13.minusWeeks(1), date( 1982, december, 6) );
+    assertEquals( date_1982_12_13.minusWeeks(3), date( 1982, november, 22) );
+    assertEquals( date_1982_12_13.minusWeeks(3).dayOfWeek, date( 1982, november, 22).dayOfWeek );
 }
 
 shared test void testWithDay() {
-    assertEquals( data_1982_12_13.withDay(13), data_1982_12_13 );
-    assertEquals( data_1982_12_13.withDay(17), date( 1982, december, 17) );
-    assertTrue( data_1982_12_13.withDay(17) <=> date( 1982, december, 17) == equal);
+    assertEquals( date_1982_12_13.withDay(13), date_1982_12_13 );
+    assertEquals( date_1982_12_13.withDay(17), date( 1982, december, 17) );
+    assertTrue( date_1982_12_13.withDay(17) <=> date( 1982, december, 17) == equal);
 }
 
-shared test void testWithDay40() {
-    try {
-        data_1982_12_13.withDay(40);
-        fail("Should throw exception...");
-    } catch( AssertionError e ) {
-        assertTrue(e.message.contains("Invalid date"));
-    }
-}
+void assertThrowsInvalidDate(void operation())
+        => assertThat(operation).hasMessage((String message) => message.contains("Invalid date value"));
 
-shared test void testWithDay0() {
-    try {
-        data_1982_12_13.withDay(0);
-        fail("Should throw exception...");
-    } catch( AssertionError e ) {
-        assertTrue(e.message.contains("Invalid date"));
-    }
-}
+shared test void testWithDay40() => assertThrowsInvalidDate {
+    void operation() => date_1982_12_13.withDay(40);
+};
 
-shared test void testWithDayNegative() {
-    try {
-        data_1982_12_13.withDay(-10);
-        fail("Should throw exception...");
-    } catch( AssertionError e ) {
-        assertTrue(e.message.contains("Invalid date"));
-    }
-}
+shared test void testWithDay0() => assertThrowsInvalidDate {
+    void operation() => date_1982_12_13.withDay(0);
+};
 
-shared test void testWithDay29FebNotLeap() {
-    try {
-        date(2011, february,1).withDay(29);
-        fail("Should throw exception...");
-    } catch( AssertionError e ) {
-        assertTrue(e.message.contains("Invalid date"));
-    }
-}
+shared test void testWithDayNegative() => assertThrowsInvalidDate {
+    void operation() => date_1982_12_13.withDay(-10);
+};
+
+shared test void testWithDay29FebNotLeap() => assertThrowsInvalidDate {
+    void operation() => date(2011, february,1).withDay(29);
+};
 
 shared test void testWithDay29FebLeap() {
     assertEquals( date(2012, february,1).withDay(29), date(2012, february, 29) );
-}    
-
-
-shared test void testWithMonthLessDaysException() {
-    try {
-        date(2012, december, 31).withMonth(february);
-        fail("Should throw exception...");
-    } catch( AssertionError e ) {
-        assertTrue(e.message.contains("Invalid date"));
-    }
 }
 
+
+shared test void testWithMonthLessDaysException() => assertThrowsInvalidDate {
+    void operation() => date(2012, december, 31).withMonth(february);
+};
+
 shared test void testWithMonth() {
-    assertEquals( data_1982_12_13, data_1982_12_13.withMonth(december) );
-    assertEquals( date( 1982, january, 13), data_1982_12_13.withMonth(january) );
-    assertTrue( data_1982_12_13.withMonth(january) <=> date( 1982, january, 13) == equal);
+    assertEquals( date_1982_12_13.withMonth(december), date_1982_12_13 );
+    assertEquals( date_1982_12_13.withMonth(january), date( 1982, january, 13) );
+    assertTrue( date_1982_12_13.withMonth(january) <=> date( 1982, january, 13) == equal);
 }
 
 shared test void testWithYear() {
-    assertEquals( data_1982_12_13.withYear(1982), data_1982_12_13 );
-    assertEquals( data_1982_12_13.withYear(2000), date( 2000, december, 13) );
-    assertEquals( data_1982_12_13.withYear(1800), date( 1800, december, 13) );
+    assertEquals( date_1982_12_13.withYear(1982), date_1982_12_13 );
+    assertEquals( date_1982_12_13.withYear(2000), date( 2000, december, 13) );
+    assertEquals( date_1982_12_13.withYear(1800), date( 1800, december, 13) );
 }
 
-shared test void testWithYearLeap() {
-    try {
-        date( 2012, february, 29).withYear(2011);
-        fail("Should throw exception...");
-    } catch( AssertionError e ) {
-        assertTrue(e.message.contains("Invalid date value"));
-    }
-}
+shared test void testWithYearLeap() => assertThrowsInvalidDate {
+    void operation() => date( 2012, february, 29).withYear(2011);
+};
 
 shared test void testOrdinal() {
-    Date data_1983_01_01 = date( 1983, january, 1 );
+    Date date_1983_01_01 = date( 1983, january, 1 );
     variable value cont = 0;
-    for ( Date date in data_1982_12_13..data_1983_01_01 ) {
-        assertEquals( date, data_1982_12_13.plusDays(cont++) );
+    for ( Date date in date_1982_12_13..date_1983_01_01 ) {
+        assertEquals( date_1982_12_13.plusDays(cont++), date );
     }
 }
 
@@ -267,7 +239,7 @@ shared test void testPlusPeriod_Date() {
         months = 2;
         days = 3;
     };
-    value newDataAmount = data_1982_12_13.plus( period_0001_02_03 );
+    value newDataAmount = date_1982_12_13.plus( period_0001_02_03 );
     assertEquals( newDataAmount.year, 1984 );
     assertEquals( newDataAmount.month, february );
     assertEquals( newDataAmount.day, 16 );
@@ -279,22 +251,22 @@ shared test void testMinusPeriod_Date() {
         months = 2;
         days = 3;
     };
-    value newDataAmount = data_1982_12_13.minus( period_0001_02_03 );
+    value newDataAmount = date_1982_12_13.minus( period_0001_02_03 );
     assertEquals( newDataAmount.year, 1981 );
     assertEquals( newDataAmount.month, october );
     assertEquals( newDataAmount.day, 10 );
 }
 
 shared test void testPredecessor() {
-    assertEquals(data_1982_12_13.predecessor, date(1982, december, 12));
+    assertEquals(date_1982_12_13.predecessor, date(1982, december, 12));
 }
 
 shared test void testSuccessor() {
-    assertEquals(data_1982_12_13.successor, date(1982, december, 14));
+    assertEquals(date_1982_12_13.successor, date(1982, december, 14));
 }
 
 shared test void testString() {
-    assertEquals( data_1982_12_13.string, "1982-12-13" );
+    assertEquals( date_1982_12_13.string, "1982-12-13" );
     assertEquals( date(2012, january, 1 ).string, "2012-01-01" );
     assertEquals( date(0, january, 1 ).string, "0000-01-01" );
     assertEquals( date(10, january, 1 ).string, "0010-01-01" );
@@ -306,41 +278,17 @@ shared test void testAt() {
     assertAt(2012, february, 29, 9, 10, 30, 0);
 }
 
-shared test void testAtInvalidHour() {
-    try {
-        data_1982_12_13.at( time(-10, 0) );
-        fail("Should throw exception...");
-    } catch ( AssertionError e ) {
-        assertTrue(e.message.contains("Hours value should be between 0 and 23"));
-    }
-}
+shared test void testAtInvalidHour()
+        => assertThat(() => date_1982_12_13.at( time(-10, 0) )).hasMessage((String message) => message.contains("Hours value should be between 0 and 23"));
 
-shared test void testAtInvalidMinute() {
-    try {
-        data_1982_12_13.at( time(10, 60) );
-        fail("Should throw exception...");
-    } catch ( AssertionError e ) {
-        assertTrue(e.message.contains("Minutes value should be between 0 and 59"));
-    }
-}
+shared test void testAtInvalidMinute()
+        => assertThat(() => date_1982_12_13.at( time(10, 60) )).hasMessage((String message) => message.contains("Minutes value should be between 0 and 59"));
 
-shared test void testAtInvalidSecond() {
-    try {
-        data_1982_12_13.at( time(10, 59, -1) );
-        fail("Should throw exception...");
-    } catch ( AssertionError e ) {
-        assertTrue(e.message.contains("Seconds value should be between 0 and 59"));
-    }
-}
+shared test void testAtInvalidSecond()
+        => assertThat(() => date_1982_12_13.at( time(10, 59, -1) )).hasMessage((String message) => message.contains("Seconds value should be between 0 and 59"));
 
-shared test void testAtInvalidMillis() {
-    try {
-        data_1982_12_13.at( time(10, 59, 59, 1000) );
-        fail("Should throw exception...");
-    } catch ( AssertionError e ) {
-        assertTrue(e.message.contains("Milliseconds value should be between 0 and 999"));
-    }
-}
+shared test void testAtInvalidMillis()
+        => assertThat(() => date_1982_12_13.at( time(10, 59, 59, 1000) )).hasMessage((String message) => message.contains("Milliseconds value should be between 0 and 999"));
 
 shared test void testPeriodFrom() {
     Period period = Period{ years = 2; months = 2; days = 3;};
@@ -466,8 +414,14 @@ shared test void testPeriodFromLeapYear() {
       actual = from.periodTo( to );
     };
 
-    assertEquals(to, from.plus(period));
-    assertEquals(from.minusDays(1), to.minus(period));
+    assertEquals {
+        expected = to;
+        actual = from.plus(period);
+    };
+    assertEquals {
+        expected = from.minusDays(1);
+        actual = to.minus(period);
+    };
 }
 
 shared test void testPeriodFromLeapYearNegative() {
@@ -483,8 +437,14 @@ shared test void testPeriodFromLeapYearNegative() {
       actual = from.periodTo( to );
     };
 
-    assertEquals(to, from.plus(period));
-    assertEquals(from, to.minus(period));
+    assertEquals {
+        expected = to;
+        actual = from.plus(period);
+    };
+    assertEquals {
+        expected = from;
+        actual = to.minus(period);
+    };
 }
 
 shared test void testPeriodFromDayAfter() {
@@ -543,9 +503,9 @@ shared test void testPeriodFromAfterDate() {
 }
 
 shared test void testEnumerableDate() {
-    assertEquals(data_1982_12_13.offset(data_1982_12_13) , 0);
-    assertEquals(data_1982_12_13.successor.offset(data_1982_12_13), 1);
-    assertEquals(data_1982_12_13.predecessor.offset(data_1982_12_13), - 1);
+    assertEquals(date_1982_12_13.offset(date_1982_12_13) , 0);
+    assertEquals(date_1982_12_13.successor.offset(date_1982_12_13), 1);
+    assertEquals(date_1982_12_13.predecessor.offset(date_1982_12_13), - 1);
 }
 
 shared test void testEqualsAndHashDate() {
@@ -576,24 +536,30 @@ void assertFromAndTo( Period period, Date from, Date to ) {
       actual = from.periodTo( to );
     };
 
-    assertEquals(to, from.plus(period));
-    assertEquals(from, to.minus(period));
+    assertEquals {
+        expected = to;
+        actual = from.plus(period);
+    };
+    assertEquals {
+        expected = from;
+        actual = to.minus(period);
+    };
 }
 
 void assertAt(Integer year, Month month, Integer day, Integer h, Integer min, Integer sec, Integer ms ) {
-    assertEquals( dateTime(year, month, day, h, min, sec, ms) , date(year, month, day).at( time(h, min, sec, ms) ));
+    assertEquals( date(year, month, day).at( time(h, min, sec, ms) ), dateTime(year, month, day, h, min, sec, ms) );
 }
 
 // Asserts that what we put in, we get back from the Date object
 void assertGregorianDate(Integer year, Month month, Integer day, DayOfWeek dayOfWeek, Boolean leapYear = false, Integer? dayOfYear = null ) {
     value actual = date(year, month, day);
-    assertEquals(year, actual.year);
-    assertEquals(month, actual.month);
-    assertEquals(day, actual.day);
-    assertEquals(dayOfWeek, actual.dayOfWeek);
-    assertEquals(leapYear, actual.leapYear);
+    assertEquals(actual.year, year);
+    assertEquals(actual.month, month);
+    assertEquals(actual.day, day);
+    assertEquals(actual.dayOfWeek, dayOfWeek);
+    assertEquals(actual.leapYear, leapYear);
 
     if ( exists dayOfYear ) {
-        assertEquals(dayOfYear, actual.dayOfYear);
+        assertEquals(actual.dayOfYear, dayOfYear);
     }
 }

--- a/test-source/test/ceylon/time/testDayOfWeek.ceylon
+++ b/test-source/test/ceylon/time/testDayOfWeek.ceylon
@@ -85,25 +85,25 @@ shared test void testComparable_friday_Weekday() {
 }
 
 shared test void testOrdinal_Weekday() {
-    value data_1982_12_13 = date( 1982, december, 13);
-    value data_1983_01_01 = date( 1983, january, 1 );
-    variable value dow = data_1982_12_13.dayOfWeek;
-    for ( Date date in data_1982_12_13..data_1983_01_01 ) {
-        assertEquals( date.dayOfWeek, dow++ );
+    value date_1982_12_13 = date( 1982, december, 13);
+    value date_1983_01_01 = date( 1983, january, 1 );
+    variable value dow = date_1982_12_13.dayOfWeek;
+    for ( Date date in date_1982_12_13..date_1983_01_01 ) {
+        assertEquals { actual = date.dayOfWeek; expected = dow++; };
     }
 }
 
 shared test void testParseDayOfWeek() {
-    assertEquals(sunday, parseDayOfWeek("sunday"));
-    assertEquals(monday, parseDayOfWeek("monday"));
-    assertEquals(tuesday, parseDayOfWeek("tuesday"));
-    assertEquals(wednesday, parseDayOfWeek("wednesday"));
-    assertEquals(thursday, parseDayOfWeek("thursday"));
-    assertEquals(friday, parseDayOfWeek("friday"));
-    assertEquals(saturday, parseDayOfWeek("saturday"));
+    assertEquals { expected = sunday; actual = parseDayOfWeek("sunday"); };
+    assertEquals { expected = monday; actual = parseDayOfWeek("monday"); };
+    assertEquals { expected = tuesday; actual = parseDayOfWeek("tuesday"); };
+    assertEquals { expected = wednesday; actual = parseDayOfWeek("wednesday"); };
+    assertEquals { expected = thursday; actual = parseDayOfWeek("thursday"); };
+    assertEquals { expected = friday; actual = parseDayOfWeek("friday"); };
+    assertEquals { expected = saturday; actual = parseDayOfWeek("saturday"); };
 
-    assertEquals(null, parseDayOfWeek("saturdayyy"));
-    assertEquals(monday, parseDayOfWeek("MoNdAy"));
+    assertEquals { expected = null; actual = parseDayOfWeek("saturdayyy"); };
+    assertEquals { expected = monday; actual = parseDayOfWeek("MoNdAy"); };
 }
 
 // Range test

--- a/test-source/test/ceylon/time/testDuration.ceylon
+++ b/test-source/test/ceylon/time/testDuration.ceylon
@@ -1,18 +1,16 @@
 import ceylon.test {
     assertEquals,
-    test
+    test,
+    parameters
 }
 import ceylon.time {
     Duration
 }
 
-shared test void testScalableDuration() {
-    //Rules suggested by scalable interface
-    Duration duration = Duration(1000);    
-    assertEquals(Duration(1000),   1 ** duration);
-    assertEquals(Duration(-1000), -1 ** duration);
-    assertEquals(Duration(0),      0 ** duration);
-    assertEquals(Duration(2000),   2 ** duration);
-
-    assertEquals( Duration(4000), 4 ** duration);
-}
+[[Duration, Integer]*] scalableDurationTests = [
+    for (i in { -1, 0, 1, 2, 4 })
+        [Duration(i*1000), i]
+];
+parameters (`value scalableDurationTests`)
+shared test void testScalableDuration(Duration expectedDuration, Integer scale)
+        => assertEquals { expected = expectedDuration; actual = scale ** Duration(1000); };

--- a/test-source/test/ceylon/time/testInstant.ceylon
+++ b/test-source/test/ceylon/time/testInstant.ceylon
@@ -36,36 +36,34 @@ shared class InstantTest() {
     Instant feb_13_2013_18_00_42_0057 = now( fixedTime(1360778442057) );
     
     shared test void dateReturnsCorrectDateValue() =>
-            assertEquals(feb_13_2013_18_00_42_0057.date(timeZone.utc), date(2013, february, 13));
+            assertEquals { expected = date(2013, february, 13); actual = feb_13_2013_18_00_42_0057.date(timeZone.utc); };
     
     shared test void timeReturnsCorrectTimeValue() => 
-            assertEquals(feb_13_2013_18_00_42_0057.time(timeZone.utc), time(18, 0, 42, 57));
+            assertEquals { expected = time(18, 0, 42, 57); actual = feb_13_2013_18_00_42_0057.time(timeZone.utc); };
     
-    shared test void equalsToSameInstant() {
-        assert(Instant(1360778442057) == feb_13_2013_18_00_42_0057);
-    }
+    shared test void equalsToSameInstant() =>
+            assertEquals { expected = feb_13_2013_18_00_42_0057; actual = Instant(1360778442057); };
     
-    shared test void sameHashForSameInstant() {
-        assert(Instant(1360778442057).hash == feb_13_2013_18_00_42_0057.hash);
-    }
+    shared test void sameHashForSameInstant() =>
+            assertEquals { expected = feb_13_2013_18_00_42_0057.hash; actual = Instant(1360778442057).hash; };
     
     shared test void stringPrintsISODateInUTC() {
-        assertEquals( "2013-02-13T18:00:42.057Z", Instant(1360778442057).string );
-        assertEquals( "2013-10-30T15:16:55.000Z", Instant(1383146215000).string );
+        assertEquals { expected = "2013-02-13T18:00:42.057Z"; actual = Instant(1360778442057).string; };
+        assertEquals { expected = "2013-10-30T15:16:55.000Z"; actual = Instant(1383146215000).string; };
     }
     
     shared test void plusPeriod_UTC() {
         value period = Period { years = 2; months = 1;};
         value actual = feb_13_2013_18_00_42_0057.plus(period);
-        assertEquals(date(2015,march, 13), actual.date(timeZone.utc) );
-        assertEquals(time(18, 0, 42, 57), actual.time(timeZone.utc) );
+        assertEquals { expected = date(2015,march, 13); actual = actual.date(timeZone.utc); };
+        assertEquals { expected = time(18, 0, 42, 57); actual = actual.time(timeZone.utc); };
     }
     
     shared test void minusPeriod_UTC() {
         value period = Period { years = 2; months = 1; days = 3;};
         value actual = feb_13_2013_18_00_42_0057.minus(period);
-        assertEquals(date(2011,january, 10), actual.date(timeZone.utc));
-        assertEquals(time(18, 0, 42, 57), actual.time(timeZone.utc));
+        assertEquals { expected = date(2011,january, 10); actual = actual.date(timeZone.utc); };
+        assertEquals { expected = time(18, 0, 42, 57); actual = actual.time(timeZone.utc); };
     }
     
     shared test void durationTo() {
@@ -73,7 +71,7 @@ shared class InstantTest() {
         value twoDaysAfter = Instant(feb_13_2013_18_00_42_0057.millisecondsOfEpoch + twoDaysduration );
         value duration = feb_13_2013_18_00_42_0057.durationTo( twoDaysAfter );
         
-        assertEquals( twoDaysduration, duration.milliseconds );
+        assertEquals { expected = twoDaysduration; actual = duration.milliseconds; };
     }
     
     shared test void durationFrom() {
@@ -81,20 +79,20 @@ shared class InstantTest() {
         value twoDaysBefore = Instant(feb_13_2013_18_00_42_0057.millisecondsOfEpoch - twoDaysduration );
         value duration =  feb_13_2013_18_00_42_0057.durationFrom(twoDaysBefore);
         
-        assertEquals( twoDaysduration, duration.milliseconds );
+        assertEquals { expected = twoDaysduration; actual = duration.milliseconds; };
     }
     
     shared test void enumerableIsBasedOnOffset() {
-        assert(feb_13_2013_18_00_42_0057.offset(feb_13_2013_18_00_42_0057) == 0);
-        assert(feb_13_2013_18_00_42_0057.successor.offset(feb_13_2013_18_00_42_0057) == 1);
-        assert(feb_13_2013_18_00_42_0057.predecessor.offset(feb_13_2013_18_00_42_0057) == -1);
+        assertEquals { expected = 0; actual = feb_13_2013_18_00_42_0057.offset(feb_13_2013_18_00_42_0057); };
+        assertEquals { expected = 1; actual = feb_13_2013_18_00_42_0057.successor.offset(feb_13_2013_18_00_42_0057); };
+        assertEquals { expected = -1; actual = feb_13_2013_18_00_42_0057.predecessor.offset(feb_13_2013_18_00_42_0057); };
     }
 
     
     shared test void enumerablePredecessor() {
-        assertEquals(feb_13_2013_18_00_42_0057.predecessor, feb_13_2013_18_00_42_0057.minus(oneMillisecond));
+        assertEquals { expected = feb_13_2013_18_00_42_0057.predecessor; actual = feb_13_2013_18_00_42_0057.minus(oneMillisecond); };
     }
     shared test void enumerableSuccessor() {
-        assertEquals(feb_13_2013_18_00_42_0057.successor, feb_13_2013_18_00_42_0057.plus(oneMillisecond));
+        assertEquals { expected = feb_13_2013_18_00_42_0057.successor; actual = feb_13_2013_18_00_42_0057.plus(oneMillisecond); };
     }
 }

--- a/test-source/test/ceylon/time/testMath.ceylon
+++ b/test-source/test/ceylon/time/testMath.ceylon
@@ -1,6 +1,7 @@
 import ceylon.test {
     assertEquals,
-    test
+    test,
+    parameters
 }
 import ceylon.time.internal.math {
     floor,
@@ -10,31 +11,45 @@ import ceylon.time.internal.math {
 }
 
 // Test floor function
-
-shared test void testFloorPositiveWhole() => assertEquals( 3, floor( 3.0));
-shared test void testFloorPositiveFloat() => assertEquals( 3, floor( 3.14));
-shared test void testFloorNegativeFloat() => assertEquals(-4, floor(-3.14));
-shared test void testFloorNegativeWhole() => assertEquals(-3, floor(-3.0));
+[[Integer, Float]*] floorTests = [
+    [3, 3.0],
+    [3, 3.14],
+    [-4, -3.14],
+    [-3, -3.0]
+];
+parameters (`value floorTests`)
+shared test void testFloor(Integer result, Float operand)
+        => assertEquals { expected = result; actual = floor(operand); };
 
 // Test round function
-shared test void testRoundPositiveWhole() => assertEquals(3, round(3.0));
-shared test void testRoundPositivePoint01() => assertEquals(3, round(3.1));
-shared test void testRoundPositivePoint04() => assertEquals(3, round(3.4));
-shared test void testRoundPositivePoint05() => assertEquals(4, round(3.5));
-shared test void testRoundPositivePoint06() => assertEquals(4, round(3.6));
-shared test void testRoundPositivePoint09() => assertEquals(4, round(3.9));
-shared test void testRoundNegativeWhole() => assertEquals(-3, round(-3.0));
-shared test void testRoundNegativePoint01() => assertEquals(-3, round(-3.1));
-shared test void testRoundNegativePoint04() => assertEquals(-3, round(-3.4));
-shared test void testRoundNegativePoint05() => assertEquals(-3, round(-3.5));
-shared test void testRoundNegativePoint06() => assertEquals(-4, round(-3.6));
-shared test void testRoundNegativePoint09() => assertEquals(-4, round(-3.9));
+[[Integer, Float]*] roundTests = [
+    [3, 3.0],
+    [3, 3.1],
+    [3, 3.4],
+    [4, 3.5],
+    [4, 3.6],
+    [4, 3.9],
+    [-3, -3.0],
+    [-3, -3.1],
+    [-3, -3.4],
+    [-3, -3.5],
+    [-4, -3.6],
+    [-4, -3.9]
+];
+parameters (`value roundTests`)
+shared test void testRound(Integer result, Float operand)
+        => assertEquals { expected = result; actual = round(operand); };
 
 // Test mod function
-shared test void testPositiveModPositive() => assertEquals( 4, mod( 9,  5));
-shared test void testNegativeModPositive() => assertEquals( 1, mod(-9,  5));
-shared test void testPositiveModNegative() => assertEquals(-1, mod( 9, -5));
-shared test void testNegativeModNegative() => assertEquals(-4, mod(-9, -5));
+[[Integer, Integer, Integer]*] modTests = [
+    [4, 9, 5],
+    [1, -9, 5],
+    [-1, 9, -5],
+    [-4, -9, -5]
+];
+parameters (`value modTests`)
+shared test void testMod(Integer result, Integer x, Integer y)
+        => assertEquals { expected = result; actual = mod(x, y); };
 shared test void testModulusInverted() => assertEquals(mod(-9, 5), 5 - mod(9, 5));
 shared test void testModulusTransitive() => assertEquals(3*4, mod(3*9, 3*5));
 
@@ -43,7 +58,7 @@ shared test void testAmod(){
     for ( y in range ){
         for( x in -y..y ) {
             value expected = y + mod(x, -y);
-            assertEquals(expected, amod(x, y), "``x`` amod ``y`` should be ``expected``");
+            assertEquals { expected = expected; actual = amod(x, y); message = "``x`` amod ``y`` should be ``expected``"; };
         }
     }
 }

--- a/test-source/test/ceylon/time/testMonth.ceylon
+++ b/test-source/test/ceylon/time/testMonth.ceylon
@@ -1,6 +1,7 @@
 import ceylon.test {
     assertEquals,
-    test
+    test,
+    parameters
 }
 import ceylon.time.base {
     january,
@@ -19,375 +20,172 @@ import ceylon.time.base {
     Month
 }
 
-shared test void test_january_number() => assertEquals(1, january.integer);
-shared test void test_february_number() => assertEquals(2, february.integer);
-shared test void test_march_number() => assertEquals(3, march.integer);
-shared test void test_april_number() => assertEquals(4, april.integer);
-shared test void test_may_number() => assertEquals(5, may.integer);
-shared test void test_june_number() => assertEquals(6, june.integer);
-shared test void test_july_number() => assertEquals(7, july.integer);
-shared test void test_august_number() => assertEquals(8, august.integer);
-shared test void test_september_number() => assertEquals(9, september.integer);
-shared test void test_october_number() => assertEquals(10, october.integer);
-shared test void test_november_number() => assertEquals(11, november.integer);
-shared test void test_december_number() => assertEquals(12, december.integer);
+[Integer, Month][12] month_number_tests = [
+    [1, january],
+    [2, february],
+    [3, march],
+    [4, april],
+    [5, may],
+    [6, june],
+    [7, july],
+    [8, august],
+    [9, september],
+    [10, october],
+    [11, november],
+    [12, december]
+];
+parameters (`value month_number_tests`)
+shared test void test_month_number(Integer number, Month month)
+        => assertEquals { expected = number; actual = month.integer; };
 
-shared test void test_january_string() => assertEquals("january", january.string);
-shared test void test_february_string() => assertEquals("february", february.string);
-shared test void test_march_string() => assertEquals("march", march.string);
-shared test void test_april_string() => assertEquals("april", april.string);
-shared test void test_may_string() => assertEquals("may", may.string);
-shared test void test_june_string() => assertEquals("june", june.string);
-shared test void test_july_string() => assertEquals("july", july.string);
-shared test void test_august_string() => assertEquals("august", august.string);
-shared test void test_september_string() => assertEquals("september", september.string);
-shared test void test_october_string() => assertEquals("october", october.string);
-shared test void test_november_string() => assertEquals("november", november.string);
-shared test void test_december_string() => assertEquals("december", december.string);
+[String, Month][12] month_string_tests = [
+    ["january", january],
+    ["february", february],
+    ["march", march],
+    ["april", april],
+    ["may", may],
+    ["june", june],
+    ["july", july],
+    ["august", august],
+    ["september", september],
+    ["october", october],
+    ["november", november],
+    ["december", december]
+];
+parameters (`value month_string_tests`)
+shared test void test_month_string(String string, Month month)
+        => assertEquals { expected = string; actual = month.string; };
 
-shared test void test_january_predecessor() => assertEquals(december, january.predecessor);
-shared test void test_february_predecessor() => assertEquals(january, february.predecessor);
-shared test void test_march_predecessor() => assertEquals(february, march.predecessor);
-shared test void test_april_predecessor() => assertEquals(march, april.predecessor);
-shared test void test_may_predecessor() => assertEquals(april, may.predecessor);
-shared test void test_june_predecessor() => assertEquals(may, june.predecessor);
-shared test void test_july_predecessor() => assertEquals(june, july.predecessor);
-shared test void test_august_predecessor() => assertEquals(july, august.predecessor);
-shared test void test_september_predecessor() => assertEquals(august, september.predecessor);
-shared test void test_october_predecessor() => assertEquals(september, october.predecessor);
-shared test void test_november_predecessor() => assertEquals(october, november.predecessor);
-shared test void test_december_predecessor() => assertEquals(november, december.predecessor);
+[Month, Month][12] month_predSucc_tests = [
+    [december, january],
+    [january, february],
+    [february, march],
+    [march, april],
+    [april, may],
+    [may, june],
+    [june, july],
+    [july, august],
+    [august, september],
+    [september, october],
+    [october, november],
+    [november, december]
+];
+parameters (`value month_predSucc_tests`)
+shared test void test_month_predecessor(Month predecessor, Month month)
+        => assertEquals { expected = predecessor; actual = month.predecessor; };
+parameters (`value month_predSucc_tests`)
+shared test void test_month_successor(Month month, Month successor)
+        => assertEquals { expected = successor; actual = month.successor; };
 
-shared test void test_january_successor() => assertEquals(february, january.successor);
-shared test void test_february_successor() => assertEquals(march, february.successor);
-shared test void test_march_successor() => assertEquals(april, march.successor);
-shared test void test_april_successor() => assertEquals(may, april.successor);
-shared test void test_may_successor() => assertEquals(june, may.successor);
-shared test void test_june_successor() => assertEquals(july, june.successor);
-shared test void test_july_successor() => assertEquals(august, july.successor);
-shared test void test_august_successor() => assertEquals(september, august.successor);
-shared test void test_september_successor() => assertEquals(october, september.successor);
-shared test void test_october_successor() => assertEquals(november, october.successor);
-shared test void test_november_successor() => assertEquals(december, november.successor);
-shared test void test_december_successor() => assertEquals(january, december.successor);
-
-shared test void test_monthOf_1() => assertEquals(january, monthOf(1));
-shared test void test_monthOf_2() => assertEquals(february, monthOf(2));
-shared test void test_monthOf_3() => assertEquals(march, monthOf(3));
-shared test void test_monthOf_4() => assertEquals(april, monthOf(4));
-shared test void test_monthOf_5() => assertEquals(may, monthOf(5));
-shared test void test_monthOf_6() => assertEquals(june, monthOf(6));
-shared test void test_monthOf_7() => assertEquals(july, monthOf(7));
-shared test void test_monthOf_8() => assertEquals(august, monthOf(8));
-shared test void test_monthOf_9() => assertEquals(september, monthOf(9));
-shared test void test_monthOf_10() => assertEquals(october, monthOf(10));
-shared test void test_monthOf_11() => assertEquals(november, monthOf(11));
-shared test void test_monthOf_12() => assertEquals(december, monthOf(12));
-
-shared test void test_monthOf_january() => assertEquals(january, monthOf(january));
-shared test void test_monthOf_february() => assertEquals(february, monthOf(february));
-shared test void test_monthOf_march() => assertEquals(march, monthOf(march));
-shared test void test_monthOf_april() => assertEquals(april, monthOf(april));
-shared test void test_monthOf_may() => assertEquals(may, monthOf(may));
-shared test void test_monthOf_june() => assertEquals(june, monthOf(june));
-shared test void test_monthOf_july() => assertEquals(july, monthOf(july));
-shared test void test_monthOf_august() => assertEquals(august, monthOf(august));
-shared test void test_monthOf_september() => assertEquals(september, monthOf(september));
-shared test void test_monthOf_october() => assertEquals(october, monthOf(october));
-shared test void test_monthOf_november() => assertEquals(november, monthOf(november));
-shared test void test_monthOf_december() => assertEquals(december, monthOf(december));
-
-shared test void test_january_numberOfDays() => assertEquals(31, january.numberOfDays());
-shared test void test_february_numberOfDays() => assertEquals(28, february.numberOfDays());
-shared test void test_march_numberOfDays() => assertEquals(31, march.numberOfDays());
-shared test void test_april_numberOfDays() => assertEquals(30, april.numberOfDays());
-shared test void test_may_numberOfDays() => assertEquals(31, may.numberOfDays());
-shared test void test_june_numberOfDays() => assertEquals(30, june.numberOfDays());
-shared test void test_july_numberOfDays() => assertEquals(31, july.numberOfDays());
-shared test void test_august_numberOfDays() => assertEquals(31, august.numberOfDays());
-shared test void test_september_numberOfDays() => assertEquals(30, september.numberOfDays());
-shared test void test_october_numberOfDays() => assertEquals(31, october.numberOfDays());
-shared test void test_november_numberOfDays() => assertEquals(30, november.numberOfDays());
-shared test void test_december_numberOfDays() => assertEquals(31, december.numberOfDays());
-
-shared test void test_january_numberOfDays_leapYear() => assertEquals(31, january.numberOfDays(leapYear));
-shared test void test_february_numberOfDays_leapYear() => assertEquals(29, february.numberOfDays(leapYear));
-shared test void test_march_numberOfDays_leapYear() => assertEquals(31, march.numberOfDays(leapYear));
-shared test void test_april_numberOfDays_leapYear() => assertEquals(30, april.numberOfDays(leapYear));
-shared test void test_may_numberOfDays_leapYear() => assertEquals(31, may.numberOfDays(leapYear));
-shared test void test_june_numberOfDays_leapYear() => assertEquals(30, june.numberOfDays(leapYear));
-shared test void test_july_numberOfDays_leapYear() => assertEquals(31, july.numberOfDays(leapYear));
-shared test void test_august_numberOfDays_leapYear() => assertEquals(31, august.numberOfDays(leapYear));
-shared test void test_september_numberOfDays_leapYear() => assertEquals(30, september.numberOfDays(leapYear));
-shared test void test_october_numberOfDays_leapYear() => assertEquals(31, october.numberOfDays(leapYear));
-shared test void test_november_numberOfDays_leapYear() => assertEquals(30, november.numberOfDays(leapYear));
-shared test void test_december_numberOfDays_leapYear() => assertEquals(31, december.numberOfDays(leapYear));
-
-shared test void test_january_firstDayOfYear() => assertEquals(1, january.firstDayOfYear());
-shared test void test_february_firstDayOfYear() => assertEquals(32, february.firstDayOfYear());
-shared test void test_march_firstDayOfYear() => assertEquals(60, march.firstDayOfYear());
-shared test void test_april_firstDayOfYear() => assertEquals(91, april.firstDayOfYear());
-shared test void test_may_firstDayOfYear() => assertEquals(121, may.firstDayOfYear());
-shared test void test_june_firstDayOfYear() => assertEquals(152, june.firstDayOfYear());
-shared test void test_july_firstDayOfYear() => assertEquals(182, july.firstDayOfYear());
-shared test void test_august_firstDayOfYear() => assertEquals(213, august.firstDayOfYear());
-shared test void test_september_firstDayOfYear() => assertEquals(244, september.firstDayOfYear());
-shared test void test_october_firstDayOfYear() => assertEquals(274, october.firstDayOfYear());
-shared test void test_november_firstDayOfYear() => assertEquals(305, november.firstDayOfYear());
-shared test void test_december_firstDayOfYear() => assertEquals(335, december.firstDayOfYear());
-
-shared test void test_january_firstDayOfYear_leapYear() => assertEquals(1, january.firstDayOfYear(leapYear));
-shared test void test_february_firstDayOfYear_leapYear() => assertEquals(32, february.firstDayOfYear(leapYear));
-shared test void test_march_firstDayOfYear_leapYear() => assertEquals(61, march.firstDayOfYear(leapYear));
-shared test void test_april_firstDayOfYear_leapYear() => assertEquals(92, april.firstDayOfYear(leapYear));
-shared test void test_may_firstDayOfYear_leapYear() => assertEquals(122, may.firstDayOfYear(leapYear));
-shared test void test_june_firstDayOfYear_leapYear() => assertEquals(153, june.firstDayOfYear(leapYear));
-shared test void test_july_firstDayOfYear_leapYear() => assertEquals(183, july.firstDayOfYear(leapYear));
-shared test void test_august_firstDayOfYear_leapYear() => assertEquals(214, august.firstDayOfYear(leapYear));
-shared test void test_september_firstDayOfYear_leapYear() => assertEquals(245, september.firstDayOfYear(leapYear));
-shared test void test_october_firstDayOfYear_leapYear() => assertEquals(275, october.firstDayOfYear(leapYear));
-shared test void test_november_firstDayOfYear_leapYear() => assertEquals(306, november.firstDayOfYear(leapYear));
-shared test void test_december_firstDayOfYear_leapYear() => assertEquals(336, december.firstDayOfYear(leapYear));
-
-shared test void test_compareJanuary() {
-    assertEquals(equal, january <=> january);
-    assertEquals(smaller, january <=> february);
-    assertEquals(smaller, january <=> march);
-    assertEquals(smaller, january <=> april);
-    assertEquals(smaller, january <=> may);
-    assertEquals(smaller, january <=> june);
-    assertEquals(smaller, january <=> july);
-    assertEquals(smaller, january <=> august);
-    assertEquals(smaller, january <=> september);
-    assertEquals(smaller, january <=> october);
-    assertEquals(smaller, january <=> november);
-    assertEquals(smaller, january <=> december);
+parameters (`value month_number_tests`)
+shared test void test_monthOf(Integer number, Month month) {
+    assertEquals { expected = month; actual = monthOf(number); "month of number"; };
+    assertEquals { expected = month; actual = monthOf(month); "month of month"; };
 }
 
-shared test void test_compareFebruary() {
-    assertEquals(larger, february <=> january);
-    assertEquals(equal, february <=> february);
-    assertEquals(smaller, february <=> march);
-    assertEquals(smaller, february <=> april);
-    assertEquals(smaller, february <=> may);
-    assertEquals(smaller, february <=> june);
-    assertEquals(smaller, february <=> july);
-    assertEquals(smaller, february <=> august);
-    assertEquals(smaller, february <=> september);
-    assertEquals(smaller, february <=> october);
-    assertEquals(smaller, february <=> november);
-    assertEquals(smaller, february <=> december);
+[Integer, Integer, Month][12] numberOfDays_tests = [
+    [31, 31, january],
+    [28, 29, february],
+    [31, 31, march],
+    [30, 30, april],
+    [31, 31, may],
+    [30, 30, june],
+    [31, 31, july],
+    [31, 31, august],
+    [30, 30, september],
+    [31, 31, october],
+    [30, 30, november],
+    [31, 31, december]
+];
+parameters (`value numberOfDays_tests`)
+shared test void test_numberOfDays(Integer onRegularYear, Integer onLeapYear, Month month) {
+    assertEquals { expected = onRegularYear; actual = month.numberOfDays(); "regular year"; };
+    assertEquals { expected = onLeapYear; actual = month.numberOfDays(leapYear); "leap year"; };
 }
 
-shared test void test_compareMarch() {
-    assertEquals(larger, march <=> january);
-    assertEquals(larger, march <=> february);
-    assertEquals(equal, march <=> march);
-    assertEquals(smaller, march <=> april);
-    assertEquals(smaller, march <=> may);
-    assertEquals(smaller, march <=> june);
-    assertEquals(smaller, march <=> july);
-    assertEquals(smaller, march <=> august);
-    assertEquals(smaller, march <=> september);
-    assertEquals(smaller, march <=> october);
-    assertEquals(smaller, march <=> november);
-    assertEquals(smaller, march <=> december);
+[Integer, Integer, Month][12] firstDayOfYear_tests = [
+    [1, 1, january],
+    [32, 32, february],
+    [60, 61, march],
+    [91, 92, april],
+    [121, 122, may],
+    [152, 153, june],
+    [182, 183, july],
+    [213, 214, august],
+    [244, 245, september],
+    [274, 275, october],
+    [305, 306, november],
+    [335, 336, december]
+];
+parameters (`value firstDayOfYear_tests`)
+shared test void test_firstDayOfYear(Integer onRegularYear, Integer onLeapYear, Month month) {
+    assertEquals { expected = onRegularYear; actual = month.firstDayOfYear(); "regular year"; };
+    assertEquals { expected = onLeapYear; actual = month.firstDayOfYear(leapYear); "leap year"; };
 }
 
-shared test void test_compareApril() {
-    assertEquals(larger, april <=> january);
-    assertEquals(larger, april <=> february);
-    assertEquals(larger, april <=> march);
-    assertEquals(equal, april <=> april);
-    assertEquals(smaller, april <=> may);
-    assertEquals(smaller, april <=> june);
-    assertEquals(smaller, april <=> july);
-    assertEquals(smaller, april <=> august);
-    assertEquals(smaller, april <=> september);
-    assertEquals(smaller, april <=> october);
-    assertEquals(smaller, april <=> november);
-    assertEquals(smaller, april <=> december);
+shared test void test_compare() {
+    for (i in 1:12) {
+        for (j in 1:12) {
+            assertEquals { expected = i <=> j; actual = monthOf(i) <=> monthOf(j); };
+        }
+    }
 }
 
-shared test void test_compareMay() {
-    assertEquals(larger, may <=> january);
-    assertEquals(larger, may <=> february);
-    assertEquals(larger, may <=> march);
-    assertEquals(larger, may <=> april);
-    assertEquals(equal, may <=> may);
-    assertEquals(smaller, may <=> june);
-    assertEquals(smaller, may <=> july);
-    assertEquals(smaller, may <=> august);
-    assertEquals(smaller, may <=> september);
-    assertEquals(smaller, may <=> october);
-    assertEquals(smaller, may <=> november);
-    assertEquals(smaller, may <=> december);
+[Integer, Month, Month][13] january_PlusMinusMonths_tests = [
+    [0, january, january],
+    [1, february, december],
+    [2, march, november],
+    [3, april, october],
+    [4, may, september],
+    [5, june, august],
+    [6, july, july],
+    [7, august, june],
+    [8, september, may],
+    [9, october, april],
+    [10, november, march],
+    [11, december, february],
+    [12, january, january]
+];
+parameters (`value january_PlusMinusMonths_tests`)
+shared test void test_january_plusMinusMonths(Integer offset, Month plus, Month minus) {
+    assertEquals { expected = plus; actual = january.plusMonths(offset); "plusMonths"; };
+    assertEquals { expected = minus; actual = january.minusMonths(offset); "minusMonths"; };
 }
 
-shared test void test_compareJune() {
-    assertEquals(larger, june <=> january);
-    assertEquals(larger, june <=> february);
-    assertEquals(larger, june <=> march);
-    assertEquals(larger, june <=> april);
-    assertEquals(larger, june <=> may);
-    assertEquals(equal, june <=> june);
-    assertEquals(smaller, june <=> july);
-    assertEquals(smaller, june <=> august);
-    assertEquals(smaller, june <=> september);
-    assertEquals(smaller, june <=> october);
-    assertEquals(smaller, june <=> november);
-    assertEquals(smaller, june <=> december);
+[Month, Integer, Integer][27] january_add_tests = [
+    [december, -2, -13],
+    [january, -1, -12],
+    [february, -1, -11],
+    [march, -1, -10],
+    [april, -1, -9],
+    [may, -1, -8],
+    [june, -1, -7],
+    [july, -1, -6],
+    [august, -1, -5],
+    [september, -1, -4],
+    [october, -1, -3],
+    [november, -1, -2],
+    [december, -1, -1],
+    [january, 0, 0],
+    [february, 0, 1],
+    [march, 0, 2],
+    [april, 0, 3],
+    [may, 0, 4],
+    [june, 0, 5],
+    [july, 0, 6],
+    [august, 0, 7],
+    [september, 0, 8],
+    [october, 0, 9],
+    [november, 0, 10],
+    [december, 0, 11],
+    [january, 1, 12],
+    [february, 1, 13]
+];
+parameters (`value january_add_tests`)
+shared test void test_january_add(Month expectedMonth, Integer expectedYears, Integer offset) {
+    value actual = january.add(offset);
+    assertEquals { expected = [expectedMonth, expectedYears]; actual = [actual.month, actual.years]; };
 }
-
-shared test void test_compareJuly() {
-    assertEquals(larger, july <=> january);
-    assertEquals(larger, july <=> february);
-    assertEquals(larger, july <=> march);
-    assertEquals(larger, july <=> april);
-    assertEquals(larger, july <=> may);
-    assertEquals(larger, july <=> june);
-    assertEquals(equal, july <=> july);
-    assertEquals(smaller, july <=> august);
-    assertEquals(smaller, july <=> september);
-    assertEquals(smaller, july <=> october);
-    assertEquals(smaller, july <=> november);
-    assertEquals(smaller, july <=> december);
-}
-
-shared test void test_compareAugust() {
-    assertEquals(larger, august <=> january);
-    assertEquals(larger, august <=> february);
-    assertEquals(larger, august <=> march);
-    assertEquals(larger, august <=> april);
-    assertEquals(larger, august <=> may);
-    assertEquals(larger, august <=> june);
-    assertEquals(larger, august <=> july);
-    assertEquals(equal, august <=> august);
-    assertEquals(smaller, august <=> september);
-    assertEquals(smaller, august <=> october);
-    assertEquals(smaller, august <=> november);
-    assertEquals(smaller, august <=> december);
-}
-
-shared test void test_compareSeptember() {
-    assertEquals(larger, september <=> january);
-    assertEquals(larger, september <=> february);
-    assertEquals(larger, september <=> march);
-    assertEquals(larger, september <=> april);
-    assertEquals(larger, september <=> may);
-    assertEquals(larger, september <=> june);
-    assertEquals(larger, september <=> july);
-    assertEquals(larger, september <=> august);
-    assertEquals(equal, september <=> september);
-    assertEquals(smaller, september <=> october);
-    assertEquals(smaller, september <=> november);
-    assertEquals(smaller, september <=> december);
-}
-
-shared test void test_compareOctober() {
-    assertEquals(larger, october <=> january);
-    assertEquals(larger, october <=> february);
-    assertEquals(larger, october <=> march);
-    assertEquals(larger, october <=> april);
-    assertEquals(larger, october <=> may);
-    assertEquals(larger, october <=> june);
-    assertEquals(larger, october <=> july);
-    assertEquals(larger, october <=> august);
-    assertEquals(larger, october <=> september);
-    assertEquals(equal, october <=> october);
-    assertEquals(smaller, october <=> november);
-    assertEquals(smaller, october <=> december);
-}
-
-shared test void test_compareNovember() {
-    assertEquals(larger, november <=> january);
-    assertEquals(larger, november <=> february);
-    assertEquals(larger, november <=> march);
-    assertEquals(larger, november <=> april);
-    assertEquals(larger, november <=> may);
-    assertEquals(larger, november <=> june);
-    assertEquals(larger, november <=> july);
-    assertEquals(larger, november <=> august);
-    assertEquals(larger, november <=> september);
-    assertEquals(larger, november <=> october);
-    assertEquals(equal, november <=> november);
-    assertEquals(smaller, november <=> december);
-}
-
-shared test void test_compareDecember() {
-    assertEquals(larger, december <=> january);
-    assertEquals(larger, december <=> february);
-    assertEquals(larger, december <=> march);
-    assertEquals(larger, december <=> april);
-    assertEquals(larger, december <=> may);
-    assertEquals(larger, december <=> june);
-    assertEquals(larger, december <=> july);
-    assertEquals(larger, december <=> august);
-    assertEquals(larger, december <=> september);
-    assertEquals(larger, december <=> october);
-    assertEquals(larger, december <=> november);
-    assertEquals(equal, december <=> december);
-}
-
-shared test void test_january_plusMonths() {
-    assertEquals(january, january.plusMonths(0));
-    assertEquals(february, january.plusMonths(1));
-    assertEquals(march, january.plusMonths(2));
-    assertEquals(april, january.plusMonths(3));
-    assertEquals(may, january.plusMonths(4));
-    assertEquals(june, january.plusMonths(5));
-    assertEquals(july, january.plusMonths(6));
-    assertEquals(august, january.plusMonths(7));
-    assertEquals(september, january.plusMonths(8));
-    assertEquals(october, january.plusMonths(9));
-    assertEquals(november, january.plusMonths(10));
-    assertEquals(december, january.plusMonths(11));
-    assertEquals(january, january.plusMonths(12));
-}
-
-shared test void test_january_minusMonths() {
-    assertEquals(january, january.minusMonths(0));
-    assertEquals(december, january.minusMonths(1));
-    assertEquals(november, january.minusMonths(2));
-    assertEquals(october, january.minusMonths(3));
-    assertEquals(september, january.minusMonths(4));
-    assertEquals(august, january.minusMonths(5));
-    assertEquals(july, january.minusMonths(6));
-    assertEquals(june, january.minusMonths(7));
-    assertEquals(may, january.minusMonths(8));
-    assertEquals(april, january.minusMonths(9));
-    assertEquals(march, january.minusMonths(10));
-    assertEquals(february, january.minusMonths(11));
-    assertEquals(january, january.minusMonths(12));
-}
-
-shared test void test_january_minus_13() => assertMonthAdd(january.add(-13), [december, -2]);
-shared test void test_january_minus_12() => assertMonthAdd(january.add(-12), [january, -1]);
-shared test void test_january_minus_11() => assertMonthAdd(january.add(-11), [february, -1]);
-shared test void test_january_minus_10() => assertMonthAdd(january.add(-10), [march, -1]);
-shared test void test_january_minus_9() => assertMonthAdd(january.add(-9), [april, -1]);
-shared test void test_january_minus_8() => assertMonthAdd(january.add(-8), [may, -1]);
-shared test void test_january_minus_7() => assertMonthAdd(january.add(-7), [june, -1]);
-shared test void test_january_minus_6() => assertMonthAdd(january.add(-6), [july, -1]);
-shared test void test_january_minus_5() => assertMonthAdd(january.add(-5), [august, -1]);
-shared test void test_january_minus_4() => assertMonthAdd(january.add(-4), [september, -1]);
-shared test void test_january_minus_3() => assertMonthAdd(january.add(-3), [october, -1]);
-shared test void test_january_minus_2() => assertMonthAdd(january.add(-2), [november, -1]);
-shared test void test_january_minus_1() => assertMonthAdd(january.add(-1), [december, -1]);
-shared test void test_january_plus_0() => assertMonthAdd(january.add(0), [january, 0]);
-shared test void test_january_plus_1() => assertMonthAdd(january.add(1), [february, 0]);
-shared test void test_january_plus_2() => assertMonthAdd(january.add(2), [march, 0]);
-shared test void test_january_plus_3() => assertMonthAdd(january.add(3), [april, 0]);
-shared test void test_january_plus_4() => assertMonthAdd(january.add(4), [may, 0]);
-shared test void test_january_plus_5() => assertMonthAdd(january.add(5), [june, 0]);
-shared test void test_january_plus_6() => assertMonthAdd(january.add(6), [july, 0]);
-shared test void test_january_plus_7() => assertMonthAdd(january.add(7), [august, 0]);
-shared test void test_january_plus_8() => assertMonthAdd(january.add(8), [september, 0]);
-shared test void test_january_plus_9() => assertMonthAdd(january.add(9), [october, 0]);
-shared test void test_january_plus_10() => assertMonthAdd(january.add(10), [november, 0]);
-shared test void test_january_plus_11() => assertMonthAdd(january.add(11), [december, 0]);
-shared test void test_january_plus_12() => assertMonthAdd(january.add(12), [january, 1]);
-shared test void test_january_plus_13() => assertMonthAdd(january.add(13), [february, 1]);
 
 // Enumerable tests:
 shared test void monthOffsetsAlwaysIncreasing1() => assertEquals {
@@ -414,7 +212,3 @@ shared test void monthsNeigbours() => assertEquals {
     actual = [for (i in -12..12) january.neighbour(i)];
     expected = [january, february, march, april, may, june, july, august, september, october, november, december, january, february, march, april, may, june, july, august, september, october, november, december, january];
 };
-
-void assertMonthAdd(Month.Overflow actual, [Month, Integer] expected){
-    assertEquals(expected, [actual.month, actual.years]);
-}

--- a/test-source/test/ceylon/time/testPeriods.ceylon
+++ b/test-source/test/ceylon/time/testPeriods.ceylon
@@ -39,96 +39,96 @@ shared test void testPeriodNormalizedMinuteToHour() => assertPeriodNormalized { 
 shared test void testPeriodNormalizedSecondToMinute() => assertPeriodNormalized { period = Period { minutes = 2; };  second = 120; };
 shared test void testPeriodNormalizedMilliToSecond() => assertPeriodNormalized { period = Period { seconds = 2; };  milli = 2000; };
 
-shared test void testPlus_Periods() => assertEquals( Period { years = 2; months = 6; }, oneYear.plus(oneHalfYear) );
+shared test void testPlus_Periods() => assertEquals { expected = Period { years = 2; months = 6; }; actual = oneYear.plus(oneHalfYear); };
 
-shared test void testPlusYears_Periods() => assertEquals( Period { years = 2; }, oneYear.plusYears(1) );
+shared test void testPlusYears_Periods() => assertEquals { expected = Period { years = 2; }; actual = oneYear.plusYears(1); };
 shared test void testPlusYearsSameInstance_Periods() => assertTrue( oneYear.plusYears(0) === oneYear );
 
 shared test void testPlusMonthsSameInstance_Periods() => assertTrue( twelveMonths.plusMonths(0) === twelveMonths );
-shared test void testPlusMonthsNormalized_Periods() => assertEquals( oneHalfYear, twelveMonths.normalized().plusMonths(6) );
+shared test void testPlusMonthsNormalized_Periods() => assertEquals { expected = oneHalfYear; actual = twelveMonths.normalized().plusMonths(6); };
 
-shared test void testPlusDaysPeriods() => assertEquals( Period { days = 50; }, tenDays.plusDays(40) );
+shared test void testPlusDaysPeriods() => assertEquals { expected = Period { days = 50; }; actual = tenDays.plusDays(40); };
 shared test void testPlusDaysSameInstancePeriods() => assertTrue( tenDays.plusDays(0) === tenDays );
 
-shared test void testPlusHoursPeriods() => assertEquals( Period { hours = 50; }, oneHour.plusHours(49) );
+shared test void testPlusHoursPeriods() => assertEquals { expected = Period { hours = 50; }; actual = oneHour.plusHours(49); };
 shared test void testPlusHoursSameInstancePeriods() => assertTrue( oneHour.plusHours(0) === oneHour );
 
-shared test void testPlusMinutesPeriods() => assertEquals( Period { minutes = 60; }, oneMinute.plusMinutes(59) );
+shared test void testPlusMinutesPeriods() => assertEquals { expected = Period { minutes = 60; }; actual = oneMinute.plusMinutes(59); };
 shared test void testPlusMinutesSameInstancePeriods() => assertTrue( oneMinute.plusMinutes(0) === oneMinute );
 
-shared test void testPlusSecondsPeriods() => assertEquals( Period { seconds = 60; }, oneSecond.plusSeconds(59) );
+shared test void testPlusSecondsPeriods() => assertEquals { expected = Period { seconds = 60; }; actual = oneSecond.plusSeconds(59); };
 shared test void testPlusSecondsSameInstancePeriods() => assertTrue( oneSecond.plusSeconds(0) === oneSecond );
 
-shared test void testPlusMillisecondsPeriods() => assertEquals( Period { milliseconds = 1000; }, oneMillisecond.plusMilliseconds(999) );
+shared test void testPlusMillisecondsPeriods() => assertEquals { expected = Period { milliseconds = 1000; }; actual = oneMillisecond.plusMilliseconds(999); };
 shared test void testPlusMillisecondsSameInstancePeriods() => assertTrue( oneMillisecond.plusMilliseconds(0) === oneMillisecond );
 
-shared test void testMinusYears_Periods() => assertEquals( Period { years = 0; months = 6; }, oneHalfYear.minusYears(1) );
-shared test void testMinusYearsNegative_Periods() => assertEquals( Period{ years = -1; }, oneYear.minusYears(2) );
+shared test void testMinusYears_Periods() => assertEquals { expected = Period { years = 0; months = 6; }; actual = oneHalfYear.minusYears(1); };
+shared test void testMinusYearsNegative_Periods() => assertEquals { expected = Period{ years = -1; }; actual = oneYear.minusYears(2); };
 shared test void testMinusYearsSameInstance_Periods() => assertTrue( oneHalfYear.minusYears(0) === oneHalfYear );
 
-shared test void testMinusMonths_Periods() => assertEquals( oneYear, oneHalfYear.minusMonths(6) );
-shared test void testMinusMonthsNegative_Periods() => assertEquals( Period {years = 1; months = -18;}, oneHalfYear.minusMonths(24) );
+shared test void testMinusMonths_Periods() => assertEquals { expected = oneYear; actual = oneHalfYear.minusMonths(6); };
+shared test void testMinusMonthsNegative_Periods() => assertEquals { expected = Period {years = 1; months = -18;}; actual = oneHalfYear.minusMonths(24); };
 shared test void testMinusMonthsSameInstance_Periods() => assertTrue( twelveMonths.minusMonths(0) === twelveMonths );
 
-shared test void testMinusDays_Periods() => assertEquals( Period{ days = 5; }, tenDays.minusDays(5) );
-shared test void testMinusDaysNegative_Periods() => assertEquals( Period{ days = -15; }, tenDays.minusDays(25) );
+shared test void testMinusDays_Periods() => assertEquals { expected = Period{ days = 5; }; actual = tenDays.minusDays(5); };
+shared test void testMinusDaysNegative_Periods() => assertEquals { expected = Period{ days = -15; }; actual = tenDays.minusDays(25); };
 shared test void testMinusDaysSameInstance_Periods() => assertTrue( tenDays.minusDays(0) === tenDays );
 
-shared test void testMinusHours_Periods() => assertEquals( Period { hours = 0; }, oneHour.minusHours(1) );
-shared test void testMinusHoursNegative_Periods() => assertEquals( Period { hours = -1; }, oneHour.minusHours(2) );
+shared test void testMinusHours_Periods() => assertEquals { expected = Period { hours = 0; }; actual = oneHour.minusHours(1); };
+shared test void testMinusHoursNegative_Periods() => assertEquals { expected = Period { hours = -1; }; actual = oneHour.minusHours(2); };
 shared test void testMinusHoursSameInstance_Periods() => assertTrue( oneHour.minusHours(0) === oneHour );
 
-shared test void testMinusMinutes_Periods() => assertEquals( Period{ minutes = 0; }, oneMinute.minusMinutes(1) );
-shared test void testMinusMinutesNegative_Periods() => assertEquals( Period{ minutes = -1; }, oneMinute.minusMinutes(2) );
+shared test void testMinusMinutes_Periods() => assertEquals { expected = Period{ minutes = 0; }; actual = oneMinute.minusMinutes(1); };
+shared test void testMinusMinutesNegative_Periods() => assertEquals { expected = Period{ minutes = -1; }; actual = oneMinute.minusMinutes(2); };
 shared test void testMinusMinutesSameInstance_Periods() => assertTrue( oneMinute.minusMinutes(0) === oneMinute );
 
-shared test void testMinusSeconds_Periods() => assertEquals( Period{ seconds = 0; }, oneSecond.minusSeconds(1) );
-shared test void testMinusSecondsNegative_Periods() => assertEquals( Period{ seconds = -1; }, oneSecond.minusSeconds(2) );
+shared test void testMinusSeconds_Periods() => assertEquals { expected = Period{ seconds = 0; }; actual = oneSecond.minusSeconds(1); };
+shared test void testMinusSecondsNegative_Periods() => assertEquals { expected = Period{ seconds = -1; }; actual = oneSecond.minusSeconds(2); };
 shared test void testMinusSecondsSameInstance_Periods() => assertTrue( oneSecond.minusSeconds(0) === oneSecond );
 
-shared test void testMinusMillis_Periods() => assertEquals( Period{ milliseconds = 0; }, oneMillisecond.minusMilliseconds(1) );
-shared test void testMinusMillisNegative_Periods() => assertEquals( Period{ milliseconds = -1; }, oneMillisecond.minusMilliseconds(2) );
+shared test void testMinusMillis_Periods() => assertEquals { expected = Period{ milliseconds = 0; }; actual = oneMillisecond.minusMilliseconds(1); };
+shared test void testMinusMillisNegative_Periods() => assertEquals { expected = Period{ milliseconds = -1; }; actual = oneMillisecond.minusMilliseconds(2); };
 shared test void testMinusMillisSameInstance_Periods() => assertTrue( oneMillisecond.minusMilliseconds(0) === oneMillisecond );
 
 shared test void testComparableYearMonth_Periods() => assertEquals( oneYear <=> twelveMonths, equal );
 shared test void testComparableYearYearHalf_Periods() => assertEquals( oneYear < oneHalfYear, true );
 shared test void testComparableYearHalfMonths_Periods() => assertEquals( oneHalfYear > twelveMonths, true );
 
-shared test void testWithYears_Periods() => assertEquals( Period{ years = 3; months = 6;}, oneHalfYear.withYears(3) );
-shared test void testWithMonths_Periods() => assertEquals( Period{ years = 1; months = 3;}, oneYear.withMonths(3) );
-shared test void testWithDays_Periods() => assertEquals( Period{ years = 1; days = 10; }, oneYear.withDays(10) );
-shared test void testWithHours_Periods() => assertEquals( Period{ years = 1; hours = 10; }, oneYear.withHours(10) );
-shared test void testWithMinutes_Periods() => assertEquals( Period{ years = 1; minutes = 10; }, oneYear.withMinutes(10) );
-shared test void testWithSeconds_Periods() => assertEquals( Period{ years = 1; seconds = 10; }, oneYear.withSeconds(10) );
-shared test void testWithMillis_Periods() => assertEquals( Period{ years = 1; milliseconds = 10; }, oneYear.withMilliseconds(10) );
+shared test void testWithYears_Periods() => assertEquals { expected = Period{ years = 3; months = 6;}; actual = oneHalfYear.withYears(3); };
+shared test void testWithMonths_Periods() => assertEquals { expected = Period{ years = 1; months = 3;}; actual = oneYear.withMonths(3); };
+shared test void testWithDays_Periods() => assertEquals { expected = Period{ years = 1; days = 10; }; actual = oneYear.withDays(10); };
+shared test void testWithHours_Periods() => assertEquals { expected = Period{ years = 1; hours = 10; }; actual = oneYear.withHours(10); };
+shared test void testWithMinutes_Periods() => assertEquals { expected = Period{ years = 1; minutes = 10; }; actual = oneYear.withMinutes(10); };
+shared test void testWithSeconds_Periods() => assertEquals { expected = Period{ years = 1; seconds = 10; }; actual = oneYear.withSeconds(10); };
+shared test void testWithMillis_Periods() => assertEquals { expected = Period{ years = 1; milliseconds = 10; }; actual = oneYear.withMilliseconds(10); };
 
-shared test void testStringNormalizedMillis() => assertEquals("PT360H", Period { milliseconds = 15 * milliseconds.perDay ; }.normalized().string);
-shared test void testStringNormalizedSeconds() => assertEquals("PT360H", Period { seconds = 15 * seconds.perDay ; }.normalized().string);
-shared test void testStringNormalizedMinutes() => assertEquals("PT360H", Period { minutes = 15 * minutes.perDay ; }.normalized().string);
-shared test void testStringNormalizedHours() => assertEquals("PT360H", Period { hours = 15 * hours.perDay ; }.normalized().string);
-shared test void testStringFullTime() => assertEquals("PT59H59M59.999S", Period { 
+shared test void testStringNormalizedMillis() => assertEquals { expected = "PT360H"; actual = Period { milliseconds = 15 * milliseconds.perDay ; }.normalized().string; };
+shared test void testStringNormalizedSeconds() => assertEquals { expected = "PT360H"; actual = Period { seconds = 15 * seconds.perDay ; }.normalized().string; };
+shared test void testStringNormalizedMinutes() => assertEquals { expected = "PT360H"; actual = Period { minutes = 15 * minutes.perDay ; }.normalized().string; };
+shared test void testStringNormalizedHours() => assertEquals { expected = "PT360H"; actual = Period { hours = 15 * hours.perDay ; }.normalized().string; };
+shared test void testStringFullTime() => assertEquals { expected = "PT59H59M59.999S"; actual = Period { 
                                       hours = 59;
                                       minutes = 59;
                                       seconds = 59;
                                       milliseconds = 999; 
-                                    }.string);
-shared test void testStringTimePaddedString() => assertEquals("PT1H1M1.001S", Period { 
+                                    }.string; };
+shared test void testStringTimePaddedString() => assertEquals { expected = "PT1H1M1.001S"; actual = Period { 
                                                hours = 1;
                                                minutes = 1;
                                                seconds = 1;
                                                milliseconds = 1; 
-                                            }.string);
+                                            }.string; };
 
 shared test void testScalablePeriod() {
     //Rules suggested by scalable interface
-    assertEquals(Period { years = 200; },   1 ** Period{ years = 200;});
-    assertEquals(Period { years = -200; }, -1 ** Period{ years = 200;});
-    assertEquals(Period { years = 0; },     0 ** Period{ years = 200;});
-    assertEquals(Period { years = 400; },   2 ** Period{ years = 200;});
+    assertEquals { expected = Period { years = 200; }; actual = 1 ** Period{ years = 200;}; };
+    assertEquals { expected = Period { years = -200; }; actual = -1 ** Period{ years = 200;}; };
+    assertEquals { expected = Period { years = 0; }; actual = 0 ** Period{ years = 200;}; };
+    assertEquals { expected = Period { years = 400; }; actual = 2 ** Period{ years = 200;}; };
 
     Period period = Period (4, 4, 4, 4, 4, 4);
     Period result = Period (16, 16, 16, 16, 16, 16);  
-    assertEquals( result, 4 ** period);
+    assertEquals { expected = result; actual = 4 ** period; };
 }
 
 shared test void testEqualsAndHashPeriod() {
@@ -151,16 +151,16 @@ shared test void testEqualsAndHashPeriod() {
 
 void assertPeriodNormalized( Period period, Integer year = 0, Integer month = 0, Integer day = 0, Integer hour = 0, Integer minute = 0, Integer second = 0, Integer milli = 0 ) {
     value normalized = Period { years = year; months = month; days = day; hours = hour; minutes = minute; seconds = second; milliseconds = milli;}.normalized();
-    assertEquals(period, normalized);
+    assertEquals { expected = period; actual = normalized; };
 }
 
 void assertPeriod( Integer year = 0, Integer month = 0, Integer day = 0, Integer hour = 0, Integer minute = 0, Integer second = 0, Integer milli = 0) {
     value p = Period(year, month, day, hour, minute, second, milli);
-    assertEquals(year, p.years);
-    assertEquals(month, p.months);
-    assertEquals(day, p.days);
-    assertEquals(hour, p.hours);
-    assertEquals(minute, p.minutes);
-    assertEquals(second, p.seconds);
-    assertEquals(milli, p.milliseconds);
+    assertEquals { expected = year; actual = p.years; };
+    assertEquals { expected = month; actual = p.months; };
+    assertEquals { expected = day; actual = p.days; };
+    assertEquals { expected = hour; actual = p.hours; };
+    assertEquals { expected = minute; actual = p.minutes; };
+    assertEquals { expected = second; actual = p.seconds; };
+    assertEquals { expected = milli; actual = p.milliseconds; };
 }

--- a/test-source/test/ceylon/time/testTime.ceylon
+++ b/test-source/test/ceylon/time/testTime.ceylon
@@ -1,9 +1,10 @@
 import ceylon.test {
     assertEquals,
-    fail,
     assertTrue,
     assertFalse,
-    test
+    assertThatException,
+    test,
+    parameters
 }
 import ceylon.time {
     time,
@@ -76,249 +77,160 @@ shared test void test_00_00_0_0000() => assertTime(0,0,0,0, 0, 0);
 shared test void test_23_59_59_999() => assertTime(23,59,59,999, 86399, 1439);
 
 shared test void testPlusHours() {
-    assertEquals( midnight.plusHours(15), time( 15, 0, 0, 0 ) );
-    assertEquals( time_14h_20m_07s_59ms.plusHours(20), time( 10, 20, 7, 59 ) );
-    assertEquals( time_14h_20m_07s_59ms.plusHours(13), time( 3, 20, 7, 59 ) );
-    assertEquals( time_14h_20m_07s_59ms.plusHours(7), time( 21, 20, 7, 59 ) );
-    assertEquals( time_14h_20m_07s_59ms.plusHours(2), time( 16, 20, 7, 59 ) );
+    assertEquals { expected = midnight.plusHours(15); actual = time( 15, 0, 0, 0 ); };
+    assertEquals { expected = time_14h_20m_07s_59ms.plusHours(20); actual = time( 10, 20, 7, 59 ); };
+    assertEquals { expected = time_14h_20m_07s_59ms.plusHours(13); actual = time( 3, 20, 7, 59 ); };
+    assertEquals { expected = time_14h_20m_07s_59ms.plusHours(7); actual = time( 21, 20, 7, 59 ); };
+    assertEquals { expected = time_14h_20m_07s_59ms.plusHours(2); actual = time( 16, 20, 7, 59 ); };
 
     value toTime_13 = time(09, 08, 07, 50).plusHours(28); 
-    assertEquals( 13, toTime_13.hours);
+    assertEquals { expected = 13; actual = toTime_13.hours; };
 }
 
 shared test void testMinusHours() {
-    assertEquals( midnight.minusHours(15), time( 9, 0 ) );
-    assertEquals( time_14h_20m_07s_59ms.minusHours(20), time( 18, 20, 7, 59 ) );
+    assertEquals { expected = midnight.minusHours(15); actual = time( 9, 0 ); };
+    assertEquals { expected = time_14h_20m_07s_59ms.minusHours(20); actual = time( 18, 20, 7, 59 ); };
 
-    assertEquals( time( 9, 0, 0, 0 ).minusHours(28), time( 5, 0, 0, 0 ) );
+    assertEquals { expected = time( 9, 0, 0, 0 ).minusHours(28); actual = time( 5, 0, 0, 0 ); };
 
     value time_5 = time(09, 08, 07, 0050).minusHours(28); 
-    assertEquals( 5, time_5.hours);
+    assertEquals { expected = 5; actual = time_5.hours; };
 }
 
 shared test void testPlusMinutes() {
-    assertEquals( time( 0, 15, 0, 0 ), midnight.plusMinutes(15) );
-    assertEquals( time( 15, 0, 7, 59 ), time_14h_20m_07s_59ms.plusMinutes(40) );
+    assertEquals { expected = time( 0, 15, 0, 0 ); actual = midnight.plusMinutes(15); };
+    assertEquals { expected = time( 15, 0, 7, 59 ); actual = time_14h_20m_07s_59ms.plusMinutes(40); };
 }
 
 shared test void testMinusMinutes() {
-    assertEquals( time( 23, 45, 0, 0 ), midnight.minusMinutes(15) );
-    assertEquals( time( 13, 59, 7, 59 ), time_14h_20m_07s_59ms.minusMinutes(21) );
+    assertEquals { expected = time( 23, 45, 0, 0 ); actual = midnight.minusMinutes(15); };
+    assertEquals { expected = time( 13, 59, 7, 59 ); actual = time_14h_20m_07s_59ms.minusMinutes(21); };
 }
 
 shared test void testPlusSeconds() {
-    assertEquals( midnight.plusSeconds(15), time( 0, 0, 15, 0 ) );
-    assertEquals( time_14h_20m_07s_59ms.plusSeconds(54), time( 14, 21, 1, 59 ) );
+    assertEquals { expected = midnight.plusSeconds(15); actual = time( 0, 0, 15, 0 ); };
+    assertEquals { expected = time_14h_20m_07s_59ms.plusSeconds(54); actual = time( 14, 21, 1, 59 ); };
 }
 
 shared test void testMinusSeconds() {
-    assertEquals( midnight.minusSeconds(15), time( 23, 59, 45, 0 ) );
-    assertEquals( time_14h_20m_07s_59ms.minusSeconds(21), time( 14, 19, 46, 59 ) );
+    assertEquals { expected = midnight.minusSeconds(15); actual = time( 23, 59, 45, 0 ); };
+    assertEquals { expected = time_14h_20m_07s_59ms.minusSeconds(21); actual = time( 14, 19, 46, 59 ); };
 }
 
 shared test void testPlusMilliseconds() {
-    assertEquals( time( 0, 0, 0, 20 ), midnight.plusMilliseconds( 20 ) );
-    assertEquals( time( 14, 20, 8, 0 ), time_14h_20m_07s_59ms.plusMilliseconds( 941 ) );
+    assertEquals { expected = time( 0, 0, 0, 20 ); actual = midnight.plusMilliseconds( 20 ); };
+    assertEquals { expected = time { hours = 14; minutes = 20; seconds = 8; milliseconds = 0; }; actual = time_14h_20m_07s_59ms.plusMilliseconds( 941 ); };
 }
 
 shared test void testMinusMilliseconds() {
-    assertEquals( midnight.minusMilliseconds( 20 ), time( 23, 59, 59, 980 ) );
+    assertEquals { expected = midnight.minusMilliseconds( 20 ); actual = time( 23, 59, 59, 980 ); };
     //assertEquals( time_14h_20m_07s_59ms.minusMilliseconds( 941 ), time( 14, 20, 6, 118 ) );
 }
 
-shared test void testWithHours30() {
-    try {
-        midnight.withHours( 30 );
-        fail("Should throw exception...");
-    } catch( AssertionError e ) {
-        assertTrue(e.message.contains("Hours value should be between 0 and 23"));
-    }
-}
+shared test void testWithHours30()
+        => assertThatException(() => midnight.withHours( 30 ))
+            .hasMessage((String message) => message.contains("Hours value should be between 0 and 23"));
 
-shared test void testWithHoursNegative() {
-    try {
-        midnight.withHours( -1 );
-        fail("Should throw exception...");
-    } catch( AssertionError e ) {
-        assertTrue(e.message.contains("Hours value should be between 0 and 23"));
-    }
-}
+shared test void testWithHoursNegative()
+        => assertThatException(() => midnight.withHours( -1 ))
+            .hasMessage((String message) => message.contains("Hours value should be between 0 and 23"));
 
 shared test void testWithHours() {
-    assertEquals( midnight.withHours( 20 ), time( 20, 0, 0, 0 ) );
-    assertEquals( time_14h_20m_07s_59ms.withHours( 2 ), time( 2, 20, 7, 59 ) );
+    assertEquals { expected = midnight.withHours( 20 ); actual = time( 20, 0, 0, 0 ); };
+    assertEquals { expected = time_14h_20m_07s_59ms.withHours( 2 ); actual = time( 2, 20, 7, 59 ); };
 }
 
-shared test void testWithMinutesNegative() {
-    try {
-        midnight.withMinutes( -1 );
-        fail("Should throw exception...");
-    } catch( AssertionError e ) {
-        assertTrue(e.message.contains("Minutes value should be between 0 and 59"));
-    }
-}
+shared test void testWithMinutesNegative()
+        => assertThatException(() => midnight.withMinutes( -1 ))
+            .hasMessage((String message) => message.contains("Minutes value should be between 0 and 59"));
 
-shared test void testWithMinutes60() {
-    try {
-        midnight.withMinutes( 60 );
-        fail("Should throw exception...");
-    } catch( AssertionError e ) {
-        assertTrue(e.message.contains("Minutes value should be between 0 and 59"));
-    }
-}
+shared test void testWithMinutes60()
+        => assertThatException(() => midnight.withMinutes( 60 ))
+            .hasMessage((String message) => message.contains("Minutes value should be between 0 and 59"));
 
 shared test void testWithMinutes() {
-    assertEquals( midnight.withMinutes( 20 ), time( 0, 20, 0, 0 ) );
-    assertEquals( time_14h_20m_07s_59ms.withMinutes( 2 ), time( 14, 2, 7, 59 ) );
+    assertEquals { expected = midnight.withMinutes( 20 ); actual = time( 0, 20, 0, 0 ); };
+    assertEquals { expected = time_14h_20m_07s_59ms.withMinutes( 2 ); actual = time( 14, 2, 7, 59 ); };
 }
 
-shared test void testWithSecondsNegative() {
-    try {
-        midnight.withSeconds( -1 );
-        fail("Should throw exception...");
-    } catch( AssertionError e ) {
-        assertTrue(e.message.contains("Seconds value should be between 0 and 59"));
-    }
-}
+shared test void testWithSecondsNegative()
+        => assertThatException(() => midnight.withSeconds( -1 ))
+            .hasMessage((String message) => message.contains("Seconds value should be between 0 and 59"));
 
-shared test void testWithSeconds60() {
-    try {
-        midnight.withSeconds( 60 );
-        fail("Should throw exception...");
-    } catch( AssertionError e ) {
-        assertTrue(e.message.contains("Seconds value should be between 0 and 59"));
-    }
-}
+shared test void testWithSeconds60()
+        => assertThatException(() => midnight.withSeconds( 60 ))
+            .hasMessage((String message) => message.contains("Seconds value should be between 0 and 59"));
 
 shared test void testWithSeconds() {
-    assertEquals( midnight.withSeconds( 20 ), time( 0, 0, 20, 0 ) );
-    assertEquals( time_14h_20m_07s_59ms.withSeconds( 2 ), time( 14, 20, 2, 59 ) );
+    assertEquals { expected = midnight.withSeconds( 20 ); actual = time( 0, 0, 20, 0 ); };
+    assertEquals { expected = time_14h_20m_07s_59ms.withSeconds( 2 ); actual = time( 14, 20, 2, 59 ); };
 }
 
-shared test void testWithMillisecondsNegative() {
-    try {
-        midnight.withMilliseconds( -1 );
-        fail("Should throw exception...");
-    } catch( AssertionError e ) {
-        assertTrue(e.message.contains("Milliseconds value should be between 0 and 999"));
-    }
-}
+shared test void testWithMillisecondsNegative()
+        => assertThatException(() => midnight.withMilliseconds( -1 ))
+            .hasMessage((String message) => message.contains("Milliseconds value should be between 0 and 999"));
 
-shared test void testWithMilliseconds1000() {
-    try {
-        midnight.withMilliseconds( 1000 );
-        fail("Should throw exception...");
-    } catch( AssertionError e ) {
-        assertTrue(e.message.contains("Milliseconds value should be between 0 and 999"));
-    }
-}
+shared test void testWithMilliseconds1000()
+        => assertThatException(() => midnight.withMilliseconds( 1000 ))
+            .hasMessage((String message) => message.contains("Milliseconds value should be between 0 and 999"));
 
 shared test void testWithMilliseconds() {
-    assertEquals( midnight.withMilliseconds( 20 ), time( 0, 0, 0, 20 ) );
-    assertEquals( time_14h_20m_07s_59ms.withMilliseconds( 2 ), time( 14, 20, 7, 2 ) );
+    assertEquals { expected = midnight.withMilliseconds( 20 ); actual = time( 0, 0, 0, 20 ); };
+    assertEquals { expected = time_14h_20m_07s_59ms.withMilliseconds( 2 ); actual = time( 14, 20, 7, 2 ); };
 }
 
 shared test void testPredecessor_Time() {
-    assertEquals( midnight.predecessor, time(23,59,59,999) ); 
+    assertEquals { expected = midnight.predecessor; actual = time(23,59,59,999); }; 
 }
 
 shared test void testSuccessor_Time() {
-    assertEquals( midnight.successor, time(0,0,0,001) ); 
+    assertEquals { expected = midnight.successor; actual = time(0,0,0,001); }; 
 }
 
 shared test void testString_Time() {
-    assertEquals( midnight.string, "00:00:00.000");
-    assertEquals( time_14h_20m_07s_59ms.string, "14:20:07.059");
+    assertEquals { expected = midnight.string; actual = "00:00:00.000"; };
+    assertEquals { expected = time_14h_20m_07s_59ms.string; actual = "14:20:07.059"; };
 }
 
-shared test void testPeriodFrom_Time() {
-    Period period = Period{ hours = 9; minutes = 59; seconds = 50; milliseconds = 100;};
-    Time from = time(10, 30, 20, 500);
-    Time to = time(20,30, 10, 600);
-    assertFromToTime(period, from, to);
-}
-
-shared test void testPeriodFrom_TimeNegative() {
-    Period period = Period{ hours = -9; minutes = -59; seconds = -50; milliseconds = -100;};
-    Time from = time(20,30, 10, 600);
-    Time to = time(10, 30, 20, 500);
-    assertFromToTime(period, from, to);
-}
-
-shared test void testPeriodFromHour_Time() {
-    Period period = Period{ hours = 2;};
-    Time from = time(18, 0);
-    Time to = time(20,0);
-    assertFromToTime(period, from, to);
-}
-
-shared test void testPeriodFromHour_TimeNegative() {
-    Period period = Period{ hours = -2;};
-    Time from = time(20,0);
-    Time to = time(18, 0);
-    assertFromToTime(period, from, to);
-}
-
-shared test void testPeriodFromMinSec_Time() {
-    Period period = Period{ hours = 9; minutes = 59; seconds = 59; milliseconds = 900;};
-    Time from = time(10, 0, 0, 600);
-    Time to = time(20, 0, 0, 500);
-    assertFromToTime(period, from, to);
-}
-
-shared test void testPeriodFromMinSec_TimeNegative() {
-    Period period = Period{ hours = -9; minutes = -59; seconds = -59; milliseconds = -900;};
-    Time from = time(20, 0, 0, 500);
-    Time to = time(10, 0, 0, 600);
-    assertFromToTime(period, from, to);
-}
-
-shared test void testPeriodFromMinuteBefore() {
-    Period period = Period{ hours = 9; minutes = 50; };
-    Time from = time(10, 20);
-    Time to = time(20, 10);
-    assertFromToTime(period, from, to);
-}
-
-shared test void testPeriodFromMinuteBeforeNegative() {
-    Period period = Period{ hours = -9; minutes = -50; };
-    Time from = time(20, 10);
-    Time to = time(10, 20);
-    assertFromToTime(period, from, to);
-}
-
-shared test void testPeriodFromSecondBefore() {
-    Period period = Period{ minutes = 9; seconds = 50; };
-    Time from = time(20, 10, 50);
-    Time to = time(20, 20, 40);
-    assertFromToTime(period, from, to);
-}
-
-shared test void testPeriodFromSecondBeforeNegative() {
-    Period period = Period{ minutes = -9; seconds = -50; };
-    Time from = time(20, 20, 40);
-    Time to = time(20, 10, 50);
-    assertFromToTime(period, from, to);
-}
-
-shared test void testPeriodFromMillisecondBefore() {
-    Period period = Period{ seconds = 9; milliseconds = 900; };
-    Time from = time(20, 20, 40, 500);
-    Time to = time(20, 20, 50, 400);
-    assertFromToTime(period, from, to);
-}
-
-shared test void testPeriodFromMillisecondBeforeNegative() {
-    Period period = Period{ seconds = -9; milliseconds = -900; };
-    Time from = time(20, 20, 50, 400);
-    Time to = time(20, 20, 40, 500);
-    assertFromToTime(period, from, to);
+[[Period, Time, Time]*] periodTests = [
+    [Period{ hours = 9; minutes = 59; seconds = 50; milliseconds = 100;}, time(10, 30, 20, 500), time(20,30, 10, 600)],
+    [Period{ hours = -9; minutes = -59; seconds = -50; milliseconds = -100;}, time(20,30, 10, 600), time(10, 30, 20, 500)],
+    [Period{ hours = 2;}, time(18, 0), time(20,0)],
+    [Period{ hours = -2;}, time(20,0), time(18, 0)],
+    [Period{ hours = 9; minutes = 59; seconds = 59; milliseconds = 900;}, time(10, 0, 0, 600), time(20, 0, 0, 500)],
+    [Period{ hours = -9; minutes = -59; seconds = -59; milliseconds = -900;}, time(20, 0, 0, 500), time(10, 0, 0, 600)],
+    [Period{ hours = 9; minutes = 50; }, time(10, 20),  time(20, 10)],
+    [Period{ hours = -9; minutes = -50; }, time(20, 10), time(10, 20)],
+    [Period{ minutes = 9; seconds = 50; }, time(20, 10, 50), time(20, 20, 40)],
+    [Period{ minutes = -9; seconds = -50; }, time(20, 20, 40), time(20, 10, 50)],
+    [Period{ seconds = 9; milliseconds = 900; }, time(20, 20, 40, 500), time(20, 20, 50, 400)],
+    [Period{ seconds = -9; milliseconds = -900; }, time(20, 20, 50, 400), time(20, 20, 40, 500)]
+];
+parameters (`value periodTests`)
+shared test void testPeriod(Period period, Time from, Time to) {
+    assertEquals{
+        expected = period;
+        actual = to.periodFrom( from );
+    };
+    assertEquals{
+        expected = period;
+        actual = from.periodTo( to );
+    };
+    
+    assertEquals {
+        expected = to;
+        actual = from.plus(period);
+    };
+    assertEquals {
+        expected = from;
+        actual = to.minus(period);
+    };
 }
 
 shared test void testEnumerableTime() {
-    assertEquals(time_14h_20m_07s_59ms.offset(time_14h_20m_07s_59ms), 0);
-    assertEquals(time_14h_20m_07s_59ms.successor.offset(time_14h_20m_07s_59ms), 1);
-    assertEquals(time_14h_20m_07s_59ms.predecessor.offset(time_14h_20m_07s_59ms), - 1);
+    assertEquals { expected = 0; actual = time_14h_20m_07s_59ms.offset(time_14h_20m_07s_59ms); };
+    assertEquals { expected = 1; actual = time_14h_20m_07s_59ms.successor.offset(time_14h_20m_07s_59ms); };
+    assertEquals { expected = - 1; actual = time_14h_20m_07s_59ms.predecessor.offset(time_14h_20m_07s_59ms); };
 }
 
 shared test void testEqualsAndHashTime() {
@@ -337,20 +249,6 @@ shared test void testEqualsAndHashTime() {
     assertFalse(instanceA_2 == instanceB_1);
     assertFalse(instanceA_1.hash == instanceB_1.hash);
     assertFalse(instanceA_2.hash == instanceB_1.hash);
-}
-
-void assertFromToTime( Period period, Time from, Time to ) {
-    assertEquals{
-      expected = period;
-      actual = to.periodFrom( from );
-    };
-    assertEquals{
-      expected = period;
-      actual = from.periodTo( to );
-    };
-
-    assertEquals(to, from.plus(period));
-    assertEquals(from, to.minus(period));
 }
 
 shared void assertTime( Integer hour = 0, Integer minute = 0, Integer second = 0, Integer milli = 0, Integer secondsOfDay = 0, Integer minutesOfDay = 0) {

--- a/test-source/test/ceylon/time/testTimeRange.ceylon
+++ b/test-source/test/ceylon/time/testTimeRange.ceylon
@@ -43,7 +43,7 @@ shared test void testEqualsAndHashTimeRange() {
 }
 
 shared test void testStepTime() {
-    assertEquals(milliseconds, firstQuarterDay.step);
+    assertEquals { expected = milliseconds; actual = firstQuarterDay.step; };
 }
 
 shared test void testAnyExistTime() {
@@ -83,51 +83,51 @@ shared test void testIntervalTimeReverse() {
 
 shared test void testGapTime() {
     TimeRange gap = time(6,0,0,1).rangeTo(time(17,59,59,999));
-    assertEquals(gap, firstQuarterDay.gap(lastQuarterDay));    
+    assertEquals { expected = gap; actual = firstQuarterDay.gap(lastQuarterDay); };    
 }
 
 shared test void testOverlapTime() {
     TimeRange halfFirstQuarter = time(0,0).rangeTo(time(3,0));
     TimeRange overlap = time(0,0).rangeTo(time(3,0));
 
-    assertEquals(overlap, firstQuarterDay.overlap(halfFirstQuarter));
+    assertEquals { expected = overlap; actual = firstQuarterDay.overlap(halfFirstQuarter); };
 }
 
 shared test void testStepMillisReverseTime() {
     TimeRange seconds = time(0,0,59).rangeTo(time(0,0,50));
-    assertEquals( 9 * milliseconds.perSecond + 1, seconds.size);
-    assertEquals( time(0,0,59), seconds.first);
-    assertEquals( time(0,0,50), seconds.last);
+    assertEquals { expected = 9 * milliseconds.perSecond + 1; actual = seconds.size; };
+    assertEquals { expected = time(0,0,59); actual = seconds.first; };
+    assertEquals { expected = time(0,0,50); actual = seconds.last; };
 }
 
 shared test void testStepSecondsReverseTime() {
     TimeRange interval = time(0,3).rangeTo(time(0,0)).stepBy(seconds);
-    assertEquals( 3 * seconds.perMinute +1, interval.size);
-    assertEquals( time(0,3), interval.first);
-    assertEquals( time(0,0), interval.last);
+    assertEquals { expected = 3 * seconds.perMinute +1; actual = interval.size; };
+    assertEquals { expected = time(0,3); actual = interval.first; };
+    assertEquals { expected = time(0,0); actual = interval.last; };
 }
 
 shared test void testStepMinutesReverseTime() {
     TimeRange interval = firstQuarterDayReverse.stepBy(minutes);
-    assertEquals( 6 * minutes.perHour +1, interval.size);
-    assertEquals( time(6,0), interval.first);
-    assertEquals( time(0,0), interval.last);
+    assertEquals { expected = 6 * minutes.perHour +1; actual = interval.size; };
+    assertEquals { expected = time(6,0); actual = interval.first; };
+    assertEquals { expected = time(0,0); actual = interval.last; };
 }
 
 shared test void testContainsTime() {
-    assertEquals(true, time(0,1) in firstQuarterDay);
+    assertTrue(time(0,1) in firstQuarterDay);
 }
 
 shared test void testGapTimeEmpty() {
     TimeRange noGap = time(2, 0).rangeTo(time(12, 0));
     
-    assertEquals(empty, firstQuarterDay.gap(noGap));
+    assertEquals { expected = empty; actual = firstQuarterDay.gap(noGap); };
 }
 
 shared test void testOverlapTimeEmpty() {
     TimeRange noOverlap = time(9, 0).rangeTo(time(12, 0));
 
-    assertEquals(empty, firstQuarterDay.overlap(noOverlap));
+    assertEquals { expected = empty; actual = firstQuarterDay.overlap(noOverlap); };
 }
 
 shared test void testGapRulesABSmallerCD_Time() {
@@ -288,20 +288,20 @@ shared test void testOverlapRulesABHigherCD_Time() {
 
 void assertIntervalTime( Time start, Time end, Period period, Duration? duration = null )  {
     value range = start.rangeTo(end);
-    assertEquals(period, range.period);
+    assertEquals { expected = period; actual = range.period; };
 
-    assertEquals( end, start.plus(period) );
-    assertEquals( start, end.minus(period) );
+    assertEquals { expected = end; actual = start.plus(period); };
+    assertEquals { expected = start; actual = end.minus(period); };
 
-    assertEquals( start, range.first );
-    assertEquals( end, range.last );
+    assertEquals { expected = start; actual = range.first; };
+    assertEquals { expected = end; actual = range.last; };
 
     if( exists duration ) {
-        assertEquals(duration, range.duration);
+        assertEquals { expected = duration; actual = range.duration; };
     }
 }
 
 test void testTimeRangeString() {
-    assertEquals( "09:10:11.000/11:00:00.999", TimeRange(time(9, 10, 11), time(11, 0, 0, 999)).string );
-    assertEquals( "23:00:00.000/00:00:00.000", TimeRange(time(23, 0), time(0, 0)).string );
+    assertEquals { expected = "09:10:11.000/11:00:00.999"; actual = TimeRange(time(9, 10, 11), time(11, 0, 0, 999)).string; };
+    assertEquals { expected = "23:00:00.000/00:00:00.000"; actual = TimeRange(time(23, 0), time(0, 0)).string; };
 }

--- a/test-source/test/ceylon/time/testTimeZone.ceylon
+++ b/test-source/test/ceylon/time/testTimeZone.ceylon
@@ -7,43 +7,47 @@ import ceylon.time.timezone { timeZone, OffsetTimeZone }
 shared test void offsetTimeZoneAlwaysReturnsConstantOffset() {
     value timeZone = OffsetTimeZone(2222);
     
-    assertEquals(2222, timeZone.offset(now()));
+    assertEquals { expected = 2222; actual = timeZone.offset(now()); };
 }
 
 shared test void testDateTimeToInstantUsesOffset() {
     value localDate = date(2013, september, 02);
 
-    assertEquals( localDate.at(time(12, 00)).instant( timeZone.utc ), 
-                  localDate.at(time(15, 00)).instant( timeZone.offset( +3 ) ),
-                  "Should apply positive timezone offset" );
+    assertEquals {
+        expected = localDate.at(time(12, 00)).instant( timeZone.utc );
+        actual = localDate.at(time(15, 00)).instant( timeZone.offset( +3 ) );
+        "Should apply positive timezone offset";
+    };
     
-    assertEquals( localDate.at(time(12, 00)).instant( timeZone.utc ), 
-                  localDate.at(time( 9, 00)).instant( timeZone.offset( -3 ) ),
-                  "Should apply negative timezone offset" );
+    assertEquals {
+        expected = localDate.at(time(12, 00)).instant( timeZone.utc );
+        actual = localDate.at(time( 9, 00)).instant( timeZone.offset( -3 ) );
+        "Should apply negative timezone offset";
+    };
 }
 
 shared test void testInstantToTimeUsesOffset() {
     value instant = Instant( 1378123200000 ); // September 2. 2013 12:00 UTC
     
-    assertEquals( time(12, 00), instant.time( timeZone.utc ) );
-    assertEquals( time(15, 00), instant.time( timeZone.offset( 3) ) );
-    assertEquals( time( 9, 00), instant.time( timeZone.offset(-3) ) );
+    assertEquals { expected = time(12, 00); actual = instant.time( timeZone.utc ); };
+    assertEquals { expected = time(15, 00); actual = instant.time( timeZone.offset( 3) ); };
+    assertEquals { expected = time( 9, 00); actual = instant.time( timeZone.offset(-3) ); };
 }
 
 shared test void testInstantToDateUsesOffset() {
     value instant = Instant( 1378123200000 ); // September 2. 2013 12:00 UTC
     
-    assertEquals( date(2013, september, 02), instant.date( timeZone.utc ) );
-    assertEquals( date(2013, september, 03), instant.plus( Period{ hours = 2; }).date( timeZone.offset( 12) ) );
-    assertEquals( date(2013, september, 01), instant.minus(Period{ hours = 2; }).date( timeZone.offset(-12) ) );
+    assertEquals { expected = date(2013, september, 02); actual = instant.date( timeZone.utc ); };
+    assertEquals { expected = date(2013, september, 03); actual = instant.plus( Period{ hours = 2; }).date( timeZone.offset( 12) ); };
+    assertEquals { expected = date(2013, september, 01); actual = instant.minus(Period{ hours = 2; }).date( timeZone.offset(-12) ); };
 }
 
 shared test void testInstantToDateTimeUsesOffset() {
     value instant = Instant( 1378123200000 ); // September 2. 2013 12:00 UTC
     
-    assertEquals( dateTime(2013, september, 02, 12, 00), instant.dateTime( timeZone.utc ) );
-    assertEquals( dateTime(2013, september, 03,  2, 00), instant.plus( Period{ hours = 2; }).dateTime( timeZone.offset( 12) ) );
-    assertEquals( dateTime(2013, september, 01, 22, 00), instant.minus(Period{ hours = 2; }).dateTime( timeZone.offset(-12) ) );
+    assertEquals { expected = dateTime(2013, september, 02, 12, 00); actual = instant.dateTime( timeZone.utc ); };
+    assertEquals { expected = dateTime(2013, september, 03,  2, 00); actual = instant.plus( Period{ hours = 2; }).dateTime( timeZone.offset( 12) ); };
+    assertEquals { expected = dateTime(2013, september, 01, 22, 00); actual = instant.minus(Period{ hours = 2; }).dateTime( timeZone.offset(-12) ); };
 }
 
 shared test void testEqualsAndHashOffsetTimeZone() {
@@ -65,11 +69,11 @@ shared test void testEqualsAndHashOffsetTimeZone() {
 }
 
 shared test void testTimeZoneString() {
-    assertEquals("+10:09", OffsetTimeZone(10 * milliseconds.perHour + 9 * milliseconds.perMinute).string);
-    assertEquals("-05:20", OffsetTimeZone(-5 * milliseconds.perHour - 20 * milliseconds.perMinute).string);
-    assertEquals("+00:00", OffsetTimeZone(0).string);
+    assertEquals { expected = "+10:09"; actual = OffsetTimeZone(10 * milliseconds.perHour + 9 * milliseconds.perMinute).string; };
+    assertEquals { expected = "-05:20"; actual = OffsetTimeZone(-5 * milliseconds.perHour - 20 * milliseconds.perMinute).string; };
+    assertEquals { expected = "+00:00"; actual = OffsetTimeZone(0).string; };
 }
 
 shared test void offsetTimeZoneToString(){
-    assertEquals("Z", timeZone.utc.string);
+    assertEquals { expected = "Z"; actual = timeZone.utc.string; };
 }

--- a/test-source/test/ceylon/time/testUtils.ceylon
+++ b/test-source/test/ceylon/time/testUtils.ceylon
@@ -1,7 +1,7 @@
-
 import ceylon.test {
     assertEquals,
-    test
+    test,
+    parameters
 }
 import ceylon.time.internal {
     overlap,
@@ -12,81 +12,97 @@ Integer a = 1;
 Integer b = 2;
 Integer c = 3;
 Integer d = 4;
-Integer e = 5;
-Integer f = 6;
 
+[<Integer[2]|[]->[Integer[2][2]*]>*] overlap_tests = [
+    empty->[
+        [[a, b], [c, d]],
+        [[b, a], [c, d]],
+        [[a, b], [d, c]],
+        [[b, a], [d, c]],
+        [[c, d], [a, b]],
+        [[d, c], [a, b]],
+        [[c, d], [b, a]],
+        [[d, c], [b, a]]
+    ],
+    [b, c]->[
+        [[a, c], [b, d]],
+        [[c, a], [b, d]],
+        [[a, c], [d, b]],
+        [[c, a], [d, b]],
+        [[b, d], [a, c]],
+        [[d, b], [a, c]],
+        [[b, d], [c, a]],
+        [[d, b], [c, a]]
+    ],
+    [b, b]->[
+        [[a, b], [b, c]],
+        [[b, a], [b, c]],
+        [[a, b], [c, b]],
+        [[b, a], [c, b]],
+        [[b, c], [a, b]],
+        [[c, b], [a, b]],
+        [[b, c], [b, a]],
+        [[c, b], [b, a]]
+    ],
+    [b, c]->[
+        [[a, d], [b, c]],
+        [[d, a], [b, c]],
+        [[a, d], [c, b]],
+        [[d, a], [c, b]],
+        [[b, c], [a, d]],
+        [[c, b], [a, d]],
+        [[b, c], [d, a]],
+        [[c, b], [d, a]]
+    ]
+];
+[[Integer[2]|[], Integer[2], Integer[2]]*] overlap_tests_params
+        => [for (overlap->ranges in overlap_tests) for ([first, second] in ranges) [overlap, first, second]];
 
-// Empty overlap cases
-shared test void test_ab_overlap_cd_is_empty() => assertEquals(empty, overlap([a, b], [c, d]));
-shared test void test_ba_overlap_cd_is_empty() => assertEquals(empty, overlap([b, a], [c, d]));
-shared test void test_ab_overlap_dc_is_empty() => assertEquals(empty, overlap([a, b], [d, c]));
-shared test void test_ba_overlap_dc_is_empty() => assertEquals(empty, overlap([b, a], [d, c]));
-shared test void test_cd_overlap_ab_is_empty() => assertEquals(empty, overlap([c, d], [a, b]));
-shared test void test_dc_overlap_ab_is_empty() => assertEquals(empty, overlap([d, c], [a, b]));
-shared test void test_cd_overlap_ba_is_empty() => assertEquals(empty, overlap([c, d], [b, a]));
-shared test void test_dc_overlap_ba_is_empty() => assertEquals(empty, overlap([d, c], [b, a]));
+parameters (`value overlap_tests_params`)
+shared test void test_overlap(Integer[2]|[] expectedOverlap, Integer[2] first, Integer[2] second)
+        => assertEquals {
+            expected = expectedOverlap;
+            actual = overlap(first, second);
+        };
 
-// simple partial overlap cases
-shared test void test_ac_overlap_bd_is_bc() => assertEquals([b, c], overlap([a, c], [b, d]));
-shared test void test_ca_overlap_bd_is_bc() => assertEquals([b, c], overlap([c, a], [b, d]));
-shared test void test_ac_overlap_db_is_bc() => assertEquals([b, c], overlap([a, c], [d, b]));
-shared test void test_ca_overlap_db_is_bc() => assertEquals([b, c], overlap([c, a], [d, b]));
-shared test void test_bd_overlap_ac_is_bc() => assertEquals([b, c], overlap([b, d], [a, c]));
-shared test void test_db_overlap_ac_is_bc() => assertEquals([b, c], overlap([d, b], [a, c]));
-shared test void test_bd_overlap_ca_is_bc() => assertEquals([b, c], overlap([b, d], [c, a]));
-shared test void test_db_overlap_ca_is_bc() => assertEquals([b, c], overlap([d, b], [c, a]));
+[<Integer[2]|[]->[Integer[2][2]*]>*] gap_tests = [
+    empty->[
+        [[a, c], [b, d]],
+        [[c, a], [b, d]],
+        [[a, c], [d, b]],
+        [[c, a], [d, b]],
+        [[b, d], [a, c]],
+        [[d, b], [a, c]],
+        [[b, d], [c, a]],
+        [[d, b], [c, a]]
+    ],
+    [b, c]->[
+        [[a, b], [c, d]],
+        [[b, a], [c, d]],
+        [[a, b], [d, c]],
+        [[b, a], [d, c]],
+        [[c, d], [a, b]],
+        [[d, c], [a, b]],
+        [[c, d], [b, a]],
+        [[d, c], [b, a]]
+    ],
+    empty->[
+        [[a, b], [b, c]],
+        [[b, a], [b, c]],
+        [[a, b], [c, b]],
+        [[b, a], [c, b]],
+        [[b, c], [a, b]],
+        [[c, b], [a, b]],
+        [[b, c], [b, a]],
+        [[c, b], [b, a]]
+    ]
+];
+[[Integer[2]|[], Integer[2], Integer[2]]*] gap_tests_params
+        => [for (gap->ranges in gap_tests) for ([first, second] in ranges) [gap, first, second]];
 
-// one element partial overlap cases
-shared test void test_ab_overlap_bc_is_bb() => assertEquals([b, b], overlap([a, b], [b, c]));
-shared test void test_ba_overlap_bc_is_bb() => assertEquals([b, b], overlap([b, a], [b, c]));
-shared test void test_ab_overlap_cb_is_bb() => assertEquals([b, b], overlap([a, b], [c, b]));
-shared test void test_ba_overlap_cb_is_bb() => assertEquals([b, b], overlap([b, a], [c, b]));
-shared test void test_bc_overlap_ab_is_bb() => assertEquals([b, b], overlap([b, c], [a, b]));
-shared test void test_cb_overlap_ab_is_bb() => assertEquals([b, b], overlap([c, b], [a, b]));
-shared test void test_bc_overlap_ba_is_bb() => assertEquals([b, b], overlap([b, c], [b, a]));
-shared test void test_cb_overlap_ba_is_bb() => assertEquals([b, b], overlap([c, b], [b, a]));
-
-// full encasement overlap (subset) cases
-shared test void test_ad_overlap_bc_is_bc() => assertEquals([b, c], overlap([a, d], [b, c]));
-shared test void test_da_overlap_bc_is_bc() => assertEquals([b, c], overlap([d, a], [b, c]));
-shared test void test_ad_overlap_cb_is_bc() => assertEquals([b, c], overlap([a, d], [c, b]));
-shared test void test_da_overlap_cb_is_bc() => assertEquals([b, c], overlap([d, a], [c, b]));
-shared test void test_bc_overlap_ad_is_bc() => assertEquals([b, c], overlap([b, c], [a, d]));
-shared test void test_cb_overlap_ad_is_bc() => assertEquals([b, c], overlap([c, b], [a, d]));
-shared test void test_bc_overlap_da_is_bc() => assertEquals([b, c], overlap([b, c], [d, a]));
-shared test void test_cb_overlap_da_is_bc() => assertEquals([b, c], overlap([c, b], [d, a]));
-
-
-shared test void testGapFunction(){
-    assertGapEquals(empty, [1, 3], [2, 4]);
-    assertGapEquals(empty, [3, 1], [2, 4]);
-    assertGapEquals(empty, [1, 3], [4, 2]);
-    assertGapEquals(empty, [3, 1], [4, 2]);
-    assertGapEquals(empty, [2, 4], [1, 3]);
-    assertGapEquals(empty, [4, 2], [1, 3]);
-    assertGapEquals(empty, [2, 4], [3, 1]);
-    assertGapEquals(empty, [4, 2], [3, 1]);
-    
-    assertGapEquals([2, 3], [1, 2], [3, 4]);
-    assertGapEquals([2, 3], [2, 1], [3, 4]);
-    assertGapEquals([2, 3], [1, 2], [4, 3]);
-    assertGapEquals([2, 3], [2, 1], [4, 3]);
-    assertGapEquals([2, 3], [3, 4], [1, 2]);
-    assertGapEquals([2, 3], [4, 3], [1, 2]);
-    assertGapEquals([2, 3], [3, 4], [2, 1]);
-    assertGapEquals([2, 3], [4, 3], [2, 1]);
-    
-    assertGapEquals(empty, [1, 2], [2, 3]);
-    assertGapEquals(empty, [2, 1], [2, 3]);
-    assertGapEquals(empty, [1, 2], [3, 2]);
-    assertGapEquals(empty, [2, 1], [3, 2]);
-    assertGapEquals(empty, [3, 2], [1, 2]);
-    assertGapEquals(empty, [2, 3], [1, 2]);
-    assertGapEquals(empty, [3, 2], [2, 1]);
-    assertGapEquals(empty, [2, 3], [2, 1]);
-}
-
-void assertGapEquals<Value>([Value, Value]|Empty expected, [Value, Value] first, [Value, Value] second)()
-              given Value satisfies Comparable<Value> & Enumerable<Value>{
-    assertEquals(expected, gap(first, second));
-}
+parameters (`value gap_tests_params`)
+shared test void test_gap(Integer[2]|[] expectedGap, Integer[2] first, Integer[2] second)
+        => assertEquals {
+            expected = expectedGap;
+            actual = gap(first, second);
+        };

--- a/test-source/test/ceylon/time/testZoneDateTime.ceylon
+++ b/test-source/test/ceylon/time/testZoneDateTime.ceylon
@@ -38,21 +38,21 @@ shared class OffsetZoneDateTimeTest() {
     
     
     shared test void utcTimeHasNoOffset() =>
-            assertEquals(september2_12am.zoneDateTime( timeZone.utc ).time, time(12, 00));
+            assertEquals { expected = september2_12am.zoneDateTime( timeZone.utc ).time; actual = time(12, 00); };
     shared test void utcDateIsNotAffected() =>
-            assertEquals(september2_12am.zoneDateTime( timeZone.utc ).date, date(2013, september, 2));
+            assertEquals { expected = september2_12am.zoneDateTime( timeZone.utc ).date; actual = date(2013, september, 2); };
 
     
     shared test void positiveOffsetAffectsTime() =>
-            assertEquals(september2_12am.zoneDateTime( timeZone.offset(+3) ).time, time(15, 00));
+            assertEquals { expected = september2_12am.zoneDateTime( timeZone.offset(+3) ).time; actual = time(15, 00); };
     shared test void positiveOffsetCanAffectDate() =>
-            assertEquals(september2_22am.zoneDateTime( timeZone.offset(+3) ).date, date(2013, september, 3));
+            assertEquals { expected = september2_22am.zoneDateTime( timeZone.offset(+3) ).date; actual = date(2013, september, 3); };
 
     
     shared test void negativeOffsetAffectsTime() =>
-            assertEquals(september2_12am.zoneDateTime( timeZone.offset(-4) ).time, time(8, 00));
+            assertEquals { expected = september2_12am.zoneDateTime( timeZone.offset(-4) ).time; actual = time(8, 00); };
     shared test void negativeOffsetCanAffectDate() =>
-            assertEquals(september2_02am.zoneDateTime( timeZone.offset(-4) ).date, date(2013, september, 1));
+            assertEquals { expected = september2_02am.zoneDateTime( timeZone.offset(-4) ).date; actual = date(2013, september, 1); };
     
 }
 


### PR DESCRIPTION
- Many, MANY tests were calling `assertEquals` with the wrong argument order: `assertEquals(expected, actual)`, whereas the correct order with positional arguments is `assertEquals(actual, expected)`. A few of these mistakes were caught by ceylon/ceylon#6183. I attempted to fix them in a way that would be consistent with other tests in the file, so sometimes I swapped the parameters, and sometimes I changed the invocation to use named arguments.
- Some tests did manual exception handling instead of using `assertThatException`.
- Some tests could be parameterized (#159).