### PR TITLE
Implements #594

### DIFF
--- a/source/ceylon/io/translators.ceylon
+++ b/source/ceylon/io/translators.ceylon
@@ -34,15 +34,9 @@ by ("Stéphane Épardaud")
 shared Anything(ByteBuffer) stringToByteProducer
         (Charset charset, String string) {
     value encoder = charset.chunkEncoder();
-    variable value read = 0;
-    variable value firstTime = true;
+    value chars = string.iterator().next;
     void producer(ByteBuffer buffer) {
-        if (firstTime || !encoder.done) {
-            read += encoder.convert(buffer, string[read...]);
-            firstTime = false;
-        } else {
-            encoder.convert(buffer, empty);
-        }
+        encoder.convert(buffer, chars);
     }
     return producer;
 }


### PR DESCRIPTION
convert now takes a provider input function instead of an Iterable.

As I know the purpose of the convert() function only by its documentation, I'm somewhat speculating what was intended. Thus, this PR is intended as a suggestion.