### PR TITLE
Added support for raw HTML

### DIFF
--- a/source/ceylon/html/Node.ceylon
+++ b/source/ceylon/html/Node.ceylon
@@ -44,7 +44,7 @@ shared class Comment(
     
 }
 
-"Represents _raw HTML_."
+"Represents _raw HTML_. Raw content is not escaped."
 shared class Raw(
 	"The raw HTML content"
 	shared String data) 

--- a/source/ceylon/html/Node.ceylon
+++ b/source/ceylon/html/Node.ceylon
@@ -6,7 +6,7 @@ shared abstract class Node(
     shared Attributes attributes = [],
     "The children of this node."
     shared default {Content<Node>*} children = [])
-        of Comment | ProcessingInstruction | Element {
+        of Comment | Raw | ProcessingInstruction | Element {
     
     "A string representing this node and all children."
     shared actual String string {
@@ -29,7 +29,7 @@ shared alias Content<Item> =>
 
 
 "Alias for nodes that contains character data."
-shared alias CharacterData => String | Comment | ProcessingInstruction;
+shared alias CharacterData => String | Raw | Comment | ProcessingInstruction;
 
 
 "Represents a _comment_ in the HTML document, although it is generally not visually shown, 
@@ -44,6 +44,14 @@ shared class Comment(
     
 }
 
+"Represents _raw HTML_."
+shared class Raw(
+	"The raw HTML content"
+	shared String data) 
+    extends Node("raw") {
+    
+    shared actual {String+} children = { data };
+}
 
 "Represents a _processing instruction_."
 shared class ProcessingInstruction(

--- a/source/ceylon/html/internal/HtmlRenderer.ceylon
+++ b/source/ceylon/html/internal/HtmlRenderer.ceylon
@@ -28,11 +28,19 @@ shared class HtmlRenderer(void write(String string), RenderingConfiguration conf
         case (is Element) {
             visitElement(node);
         }
+        case (is Raw) {
+            visitRaw(node);
+        }
     }
     
     void visitComment(Comment node) {
         flush();
         write("<!-- `` node.data `` -->"); // escape?
+    }
+    
+    void visitRaw(Raw node) {
+        flush();
+        write(node.data);
     }
     
     void visitProcessingInstruction(ProcessingInstruction node) {

--- a/test-source/test/ceylon/html/TestExamples.ceylon
+++ b/test-source/test/ceylon/html/TestExamples.ceylon
@@ -67,7 +67,11 @@ shared class TestExamples() {
         assertHtml(
             Div { () => {"foo", Span {"bar"}, "baz" } },
             "<div>foo<span>bar</span>baz</div>\n"
-        );        
+        );
+        assertHtml(
+            Div { "Raw HTML:", Raw("<div></div>") },
+            "<div>Raw HTML:<div></div></div>\n"
+        );
     }
     
     test


### PR DESCRIPTION
Added a `Raw` class that can be used for raw HTML. 

Example, 

```Ceylon
Raw ("<div></div>")
```
will output `<div></div>` without escaping.