### PR TITLE
return the old value in map.put, not the new one

### DIFF
--- a/source/ceylon/interop/java/CeylonMutableMap.ceylon
+++ b/source/ceylon/interop/java/CeylonMutableMap.ceylon
@@ -14,7 +14,7 @@ shared class CeylonMutableMap<Key, Item>(JMap<Key, Item> map)
         given Key satisfies Object 
         given Item satisfies Object {
     
-    put(Key key, Item item) => map[key] = item;
+    put(Key key, Item item) => map.put(key, item);
     
     remove(Key key) => map.remove(key);
     

--- a/test-source/test/ceylon/interop/java/interopTests.ceylon
+++ b/test-source/test/ceylon/interop/java/interopTests.ceylon
@@ -29,7 +29,8 @@ import java.util {
     LinkedHashSet,
     TreeSet,
     LinkedList,
-    Date
+    Date,
+    JavaHashMap=HashMap
 }
 
 test void stringTests() {
@@ -155,6 +156,15 @@ test void ceylonStringMap() {
     assertTrue(csMap.keys.contains("two"));
     assertEquals(csMap.keys.size, 2);
     assertEquals(CeylonStringMap(emptyMap).size, 0);
+}
+
+test void ceylonMutableMap() {
+    value javaMap = JavaHashMap<String, Integer>();
+    value ceylonMap = CeylonMutableMap(javaMap);
+
+    assertEquals(1, ceylonMap["x"] = 1);
+    assertEquals(1, ceylonMap.put("x", 2));
+    assertEquals(2, ceylonMap.put("x", 3));
 }
 
 test void ceylonStringMutableMap() {


### PR DESCRIPTION
I didn't want to interfere with the release process, so I didn't push this. But it's a critical fix.

I think we should also look for other changes where the result of `put()` was used before, but is now `[]=`, but it's too late for me to do that.