### PR TITLE
Update Visitor.ceylon

### DIFF
--- a/source/ceylon/json/Visitor.ceylon
+++ b/source/ceylon/json/Visitor.ceylon
@@ -55,7 +55,7 @@ shared void visit(subject, visitor, sortedKeys=false) {
     case (is Object) {
         visitor.onStartObject();
         
-        value items = sortedKeys then subject else subject.sort(compareKeys);
+        value items = sortedKeys then subject.sort(compareKeys) else subject;
         for (key->child in items) {
             visitor.onKey(key);
             visit(child, visitor);


### PR DESCRIPTION
Bug - sorting must occurs then sortedKeys=true, not false

The code:
```
shared void jsonSort() {
    print(JsonObject({"3" -> 3, "4" -> 4, "1" -> 1}).string);
}
```

produce output - {"1":1,"3":3,"4":4}, but initial order must be the same, sorting must work only in pretty case
