### PR TITLE
Make datetime related structures serializable

### DIFF
--- a/source/ceylon/time/DateRange.ceylon
+++ b/source/ceylon/time/DateRange.ceylon
@@ -11,7 +11,7 @@ import ceylon.time.internal { _gap = gap, _overlap = overlap }
  * Allows customized way to iterate as navigate between values by [[UnitOfDate]] cases
  "
 see(`interface Range`)
-shared class DateRange( from, to, step = days ) satisfies Range<Date, UnitOfDate> {
+shared serializable class DateRange( from, to, step = days ) satisfies Range<Date, UnitOfDate> {
 
     "The first Element returned by the iterator, if any.
      This should always produce the same value as

--- a/source/ceylon/time/DateTimeRange.ceylon
+++ b/source/ceylon/time/DateTimeRange.ceylon
@@ -10,7 +10,8 @@ import ceylon.time.internal { _gap = gap, _overlap = overlap }
  * Recover the gap between [[DateTimeRange]] types
  * Allows customized way to iterate as navigate between values by [[UnitOfDate]] or [[UnitOfTime]] cases
  "
-shared class DateTimeRange( from, to, step = milliseconds ) satisfies Range<DateTime, UnitOfDate|UnitOfTime> {
+shared serializable class DateTimeRange( from, to, step = milliseconds )
+        satisfies Range<DateTime, UnitOfDate|UnitOfTime> {
 
     "The first Element returned by the iterator, if any.
      This should always produce the same value as

--- a/source/ceylon/time/Duration.ceylon
+++ b/source/ceylon/time/Duration.ceylon
@@ -1,7 +1,7 @@
 import ceylon.time.base { ReadableDuration }
 
 "Duration specifies a discreet amount of milliseconds between two instances of time."
-shared class Duration(milliseconds) satisfies ReadableDuration & Scalable<Integer, Duration> {
+shared serializable class Duration(milliseconds) satisfies ReadableDuration & Scalable<Integer, Duration> {
 
     "Number of milliseconds of this duration."
     shared actual Integer milliseconds;

--- a/source/ceylon/time/Instant.ceylon
+++ b/source/ceylon/time/Instant.ceylon
@@ -15,7 +15,7 @@ shared Instant now(Clock? clock = null) {
  
  An instant represents a single point in time irrespective of 
  any time-zone offsets or geographical locations."
-shared class Instant(millisecondsOfEpoch)
+shared serializable class Instant(millisecondsOfEpoch)
     satisfies ReadableInstant & Comparable<Instant> & Enumerable<Instant> {
 
     "Internal value of an instant as a number of milliseconds since

--- a/source/ceylon/time/Period.ceylon
+++ b/source/ceylon/time/Period.ceylon
@@ -7,7 +7,7 @@ import ceylon.time.base {
 
  A period is a human-scale description of an amount of time.
  "
-shared class Period(years=0, months=0, days=0, hours=0, minutes=0, seconds=0, milliseconds=0)
+shared serializable class Period(years=0, months=0, days=0, hours=0, minutes=0, seconds=0, milliseconds=0)
        satisfies ReadablePeriod & ReadableTimePeriod & ReadableDatePeriod
                & PeriodBehavior<Period>
                & Comparable<Period>

--- a/source/ceylon/time/TimeRange.ceylon
+++ b/source/ceylon/time/TimeRange.ceylon
@@ -11,7 +11,7 @@ import ceylon.time.internal { _gap = gap, _overlap = overlap }
  * Allows customized way to iterate as navigate between values by [[UnitOfTime]] cases
  "
 see(`interface Range`)
-shared class TimeRange( from, to, step = milliseconds ) satisfies Range<Time, UnitOfTime> {
+shared serializable class TimeRange( from, to, step = milliseconds ) satisfies Range<Time, UnitOfTime> {
 
     "The first Element returned by the iterator, if any.
      This should always produce the same value as

--- a/source/ceylon/time/internal/GregorianDate.ceylon
+++ b/source/ceylon/time/internal/GregorianDate.ceylon
@@ -3,7 +3,7 @@ import ceylon.time.base { DayOfWeek, weekdayOf=dayOfWeek, monthOf, Month, days, 
 import ceylon.time.chronology { impl=gregorian }
 
 "Default implementation of a gregorian calendar"
-shared class GregorianDate( dayOfEra ) extends Object() satisfies Date {
+shared serializable class GregorianDate( dayOfEra ) extends Object() satisfies Date {
 	
 	"Every [[Date]] implementation should indicate it´s own _day of era_ based in it´s own chronology."
 	shared actual Integer dayOfEra;

--- a/source/ceylon/time/internal/GregorianDateTime.ceylon
+++ b/source/ceylon/time/internal/GregorianDateTime.ceylon
@@ -5,7 +5,7 @@ import ceylon.time.internal.math { floorDiv, floorMod }
 import ceylon.time.timezone { TimeZone, timeZone }
 
 "Default implementation of a gregorian calendar"
-shared class GregorianDateTime( date, time ) extends Object()
+shared serializable class GregorianDateTime( date, time ) extends Object()
     satisfies DateTime {
 
     "Returns [[Date]] representation of current _date and time_."

--- a/source/ceylon/time/internal/GregorianYearMonth.ceylon
+++ b/source/ceylon/time/internal/GregorianYearMonth.ceylon
@@ -9,7 +9,7 @@ import ceylon.time.chronology {
     impl=gregorian
 }
 
-shared class GregorianYearMonth(year, month) extends Object() satisfies YearMonth {
+shared serializable class GregorianYearMonth(year, month) extends Object() satisfies YearMonth {
 
     shared actual Integer year;
 

--- a/source/ceylon/time/internal/GregorianZonedDateTime.ceylon
+++ b/source/ceylon/time/internal/GregorianZonedDateTime.ceylon
@@ -21,7 +21,7 @@ import ceylon.time.timezone {
 
  This means that making some operations like _plusDays_ takes into 
  account the result Instant generated to reapply all the rules of the current TimeZone."
-shared class GregorianZonedDateTime(instant, timeZone = tz.system) extends Object() satisfies ZoneDateTime {
+shared serializable class GregorianZonedDateTime(instant, timeZone = tz.system) extends Object() satisfies ZoneDateTime {
 
     "TimeZone to be applied in this implementation."
     shared actual TimeZone timeZone;

--- a/source/ceylon/time/internal/TimeOfDay.ceylon
+++ b/source/ceylon/time/internal/TimeOfDay.ceylon
@@ -4,7 +4,7 @@ import ceylon.time.internal.math { floorMod }
 
 "Basic implementation of [[Time]] interface, representing an abstract 
  _time of day_ such as _10am_ or _3.20pm_ with a precision of milliseconds."
-shared class TimeOfDay(millisecondsOfDay) extends Object() satisfies Time {
+shared serializable class TimeOfDay(millisecondsOfDay) extends Object() satisfies Time {
 
     "Number of milliseconds since last midnight."
     shared actual Integer millisecondsOfDay;


### PR DESCRIPTION
Date and Time data structures often used in serializable data transfer objects. So I think it must be serializable.