### PR TITLE
add function to simplify post requests

### DIFF
--- a/source/ceylon/http/client/post.ceylon
+++ b/source/ceylon/http/client/post.ceylon
@@ -1,0 +1,16 @@
+import ceylon.buffer.charset {
+	utf8
+}
+import ceylon.http.client {
+	Request
+}
+import ceylon.http.common {
+	p=post
+}
+import ceylon.uri {
+	Uri,
+	Parameter
+}
+
+"Returns an HTTP POST request for the given Uri"
+shared Request post(Uri uri, {Parameter*} parameters = empty) => Request(uri, p, null, "application/octet-stream", utf8, parameters);


### PR DESCRIPTION
Currently there is a method to write simple GET requests. This PR adds the ability for POST requests too.

Example usage: 

```ceylon
Uri uri = parse("http://httpbin.org/post");
Request request = post(uri, { Parameter("param", "33333") });
Response response = request.execute();
print(response.contents);
```

Output:

```json
{
  "args": {}, 
  "data": "", 
  "files": {}, 
  "form": {
    "param": "33333"
  }, 
  "headers": {
    "Accept": "*/*", 
    "Accept-Charset": "UTF-8", 
    "Connection": "close", 
    "Content-Length": "11", 
    "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8", 
    "Host": "httpbin.org", 
    "User-Agent": "curl/7.21.6 (x86_64-pc-linux-gnu) libcurl/7.21.6 OpenSSL/1.0.0e zlib/1.2.3.4 libidn/1.22 librtmp/2.3"
  }, 
  "json": null, 
  "origin": "xxx.xxx.xxx.xxx", 
  "url": "http://httpbin.org/post"
}
```