### PR TITLE
HTTP request locale and encoding

### DIFF
--- a/resource/test/ceylon/http/server/CharsetTestMessages.properties
+++ b/resource/test/ceylon/http/server/CharsetTestMessages.properties
@@ -1,0 +1,9 @@
+#The same original string in different charsets encoded in base64
+
+stringoriginal=String Строка
+
+utf8base64=U3RyaW5nINCh0YLRgNC+0LrQsA==
+
+cp1251base64=U3RyaW5nINHy8O7q4A==
+
+cp866base64=U3RyaW5nIJHi4K6qoA==

--- a/resource/test/ceylon/http/server/LocaleTestMessages.properties
+++ b/resource/test/ceylon/http/server/LocaleTestMessages.properties
@@ -1,0 +1,2 @@
+languagetag=default
+message=Message

--- a/resource/test/ceylon/http/server/LocaleTestMessages_de.properties
+++ b/resource/test/ceylon/http/server/LocaleTestMessages_de.properties
@@ -1,0 +1,2 @@
+languagetag=de
+message=Nachricht

--- a/resource/test/ceylon/http/server/LocaleTestMessages_en.properties
+++ b/resource/test/ceylon/http/server/LocaleTestMessages_en.properties
@@ -1,0 +1,2 @@
+languagetag=en
+message=Message

--- a/resource/test/ceylon/http/server/LocaleTestMessages_ru.properties
+++ b/resource/test/ceylon/http/server/LocaleTestMessages_ru.properties
@@ -1,0 +1,2 @@
+languagetag=ru
+message=Сообщение

--- a/source/ceylon/http/server/Request.ceylon
+++ b/source/ceylon/http/server/Request.ceylon
@@ -4,6 +4,9 @@ import ceylon.io {
 import ceylon.http.common {
     Method
 }
+import ceylon.locale {
+    Locale
+}
 
 "Defines an object to provide client request information 
  to a web endpoint."
@@ -101,6 +104,20 @@ shared interface Request {
     
     "Returns request content type, read from header."
     shared formal String? contentType;
+    
+    "Returns the preferred [[Locale]] that the client
+     accepts content in, based on the Accept-Language header.
+     If the client request doesn't provide an Accept-Language header,
+     this method returns the default locale for the server."
+    shared formal Locale locale;
+    
+    "Returns sequence of [[Locale]] objects indicating,
+     in decreasing order starting with the preferred locale, the locales
+     that are acceptable to the client based on the Accept-Language header.
+     If the client request doesn't provide an Accept-Language header,
+     this method returns sequence containing one [[Locale]],
+     the default locale for the server."
+    shared formal [Locale+] locales;
     
     "Returns users http session. If session doesn't exists, 
      a new is created."

--- a/source/ceylon/http/server/Request.ceylon
+++ b/source/ceylon/http/server/Request.ceylon
@@ -60,7 +60,11 @@ shared interface Request {
     "Get the HTTP request method.
      {OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT}"
     shared formal Method method;
-    
+
+    "Returns the request charset. If none was explicitly specified it will return
+     *ISO-8859-1*, which is the default charset for HTTP requests."
+    shared formal String requestCharset;
+
     "Get the request URI scheme. {http, https}"
     shared formal String scheme;
     

--- a/source/ceylon/http/server/internal/RequestImpl.ceylon
+++ b/source/ceylon/http/server/internal/RequestImpl.ceylon
@@ -91,11 +91,10 @@ class RequestImpl(HttpServerExchange exchange,
                 }
             }
         }
-        if (locales.empty) {
-            return [systemLocale];
-        } else {
-            assert (is [Locale+] localesSequence = locales.sequence());
+        if (nonempty localesSequence = locales.sequence()) {
             return localesSequence;
+        } else {
+            return [systemLocale];
         }
     }
     shared actual [Locale+] locales => getLocales();

--- a/source/ceylon/http/server/internal/RequestImpl.ceylon
+++ b/source/ceylon/http/server/internal/RequestImpl.ceylon
@@ -19,6 +19,11 @@ import ceylon.http.server {
 import ceylon.io {
     SocketAddress
 }
+import ceylon.locale {
+    Locale,
+    systemLocale,
+    createLocale=locale
+}
 
 import io.undertow.server {
     HttpServerExchange
@@ -34,7 +39,8 @@ import io.undertow.server.session {
 }
 import io.undertow.util {
     Headers,
-    HttpString
+    HttpString,
+    QValueParser
 }
 
 import java.io {
@@ -67,7 +73,35 @@ class RequestImpl(HttpServerExchange exchange,
     contentType => getHeader(Headers.contentType.string);
 
     header(String name) => getHeader(name);
-    
+
+    [Locale+] getLocales() {
+        value acceptLanguage = exchange.requestHeaders.get(Headers.acceptLanguage.string);
+        if (!exists acceptLanguage) {
+            return [systemLocale];
+        }
+        if (acceptLanguage.empty) {
+            return [systemLocale];
+        }
+        value parsedResults = QValueParser.parse(acceptLanguage);
+        ArrayList<Locale> locales = ArrayList<Locale>();
+        for (qvalueResult in parsedResults) {
+            for (res in qvalueResult) {
+                if (is Locale nextLocale = createLocale(res.\ivalue.string)) {
+                    locales.add(nextLocale);
+                }
+            }
+        }
+        if (locales.empty) {
+            return [systemLocale];
+        } else {
+            assert (is [Locale+] localesSequence = locales.sequence());
+            return localesSequence;
+        }
+    }
+    shared actual [Locale+] locales => getLocales();
+
+    shared actual Locale locale => getLocales().first;
+
     shared actual String read() {
         exchange.startBlocking();
         value inputStream = exchange.inputStream;

--- a/source/ceylon/http/server/internal/RequestImpl.ceylon
+++ b/source/ceylon/http/server/internal/RequestImpl.ceylon
@@ -102,13 +102,14 @@ class RequestImpl(HttpServerExchange exchange,
 
     shared actual Locale locale => getLocales().first;
 
+    shared actual String requestCharset => exchange.requestCharset;
+
     shared actual String read() {
         exchange.startBlocking();
         value inputStream = exchange.inputStream;
         try {
             value inputStreamReader = 
-                    InputStreamReader(inputStream, 
-                        exchange.requestCharset);
+                    InputStreamReader(inputStream, requestCharset);
             value reader = BufferedReader(inputStreamReader);
             value builder = StringBuilder();
             while (exists line = reader.readLine()) {

--- a/source/ceylon/http/server/module.ceylon
+++ b/source/ceylon/http/server/module.ceylon
@@ -48,6 +48,7 @@ module ceylon.http.server maven:"org.ceylon-lang" "1.3.4-SNAPSHOT" {
     
     shared import ceylon.http.common "1.3.4-SNAPSHOT";
     shared import ceylon.collection "1.3.4-SNAPSHOT";
+    shared import ceylon.locale "1.3.4-SNAPSHOT";
     shared import ceylon.io "1.3.4-SNAPSHOT";
     shared import "com.redhat.ceylon.module-resolver" "1.3.4-SNAPSHOT";
     import ceylon.file "1.3.4-SNAPSHOT";


### PR DESCRIPTION
In the servlet (Java EE) API we can use ServletRequest.getLocale() and/or getLocales() methods for creating web pages and services with internationalization. Please add the equivalent properties in ceylon.http.server.Request. This patch was made using comments from Java EE 6 API and some code from Undertow.

Request charset getter can also be useful. The Request.read() method works fine (except of the problem discussed in #672 pull) but charset can be used outside of Request (for working with string and binary requests at the same time, for analytics and something else).